### PR TITLE
update hip ci to test versions 3.9.0 and 3.10.0

### DIFF
--- a/toss_3_x86_64_ib/packages.yaml
+++ b/toss_3_x86_64_ib/packages.yaml
@@ -19,35 +19,45 @@ packages:
     - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
   hip:
-    version: [3.7.0]
+    version: [3.9.0, 3.10.0]
     buildable: false
     externals:
-    - spec: hip@3.7.0
-      prefix: /opt/rocm-3.7.0/hip
+    - spec: hip@3.9.0
+      prefix: /opt/rocm-3.9.0/hip
+    - spec: hip@3.10.0
+      prefix: /opt/rocm-3.10.0/hip
   llvm-amdgpu:
-    version: [3.7.0]
+    version: [3.9.0, 3.10.0]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@3.7.0
-      prefix: /opt/rocm-3.7.0/llvm
+    - spec: llvm-amdgpu@3.9.0
+      prefix: /opt/rocm-3.9.0/llvm
+    - spec: llvm-amdgpu@3.10.0
+      prefix: /opt/rocm-3.10.0/llvm
   hsa-rocr-dev:
-    version: [3.7.0]
+    version: [3.9.0, 3.10.0]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@3.7.0
-      prefix: /opt/rocm-3.7.0/
+    - spec: hsa-rocr-dev@3.9.0
+      prefix: /opt/rocm-3.9.0/
+    - spec: hsa-rocr-dev@3.10.0
+      prefix: /opt/rocm-3.10.0/
   rocminfo:
-    version: [3.7.0]
+    version: [3.9.0, 3.10.0]
     buildable: false
     externals:
-    - spec: rocminfo@3.7.0
-      prefix: /opt/rocm-3.7.0/
+    - spec: rocminfo@3.9.0
+      prefix: /opt/rocm-3.9.0/
+    - spec: rocminfo@3.10.0
+      prefix: /opt/rocm-3.10.0/
   rocm-device-libs:
-    version: [3.7.0]
+    version: [3.9.0, 3.10.0]
     buildable: false
     externals:
-    - spec: rocm-device-libs@3.7.0
-      prefix: /opt/rocm-3.7.0/
+    - spec: rocm-device-libs@3.9.0
+      prefix: /opt/rocm-3.9.0/
+    - spec: rocm-device-libs@3.10.0
+      prefix: /opt/rocm-3.10.0/
   mvapich2:
     externals:
     - spec: mvapich2@2.3.1%clang@10.0.0~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32


### PR DESCRIPTION
I am just adding 3.9.0 and 3.10.0 as possible hip versions to test in the CI. I didn't see a Changelog to update and the contributing.md file is no longer around. Let me know if I should add anything else!

(I've tested this in Umpire using uberenv and both versions work on corona.)