### PR TITLE
changing spec name for clang11-ibm

### DIFF
--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -78,7 +78,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@11.0.0ibm
+    spec: clang@11ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang++


### PR DESCRIPTION
Until there is a better solution, this name change will allow the Gitlab CI clang@11 jobs to find the normal clang@11.0.0 instead of getting confused and finding clang@11.0.0-ibm instead.