### PR TITLE
changing naming format for clang-ibm

### DIFF
--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -52,7 +52,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@9.0.0ibm
+    spec: clang@9.0.0-ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang++
@@ -65,7 +65,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@10.0.1ibm
+    spec: clang@10.0.1-ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-10.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-10.0.1/bin/clang++
@@ -78,7 +78,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@11ibm
+    spec: clang@11.0.0-ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang++

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -40,9 +40,9 @@ packages:
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-4.9.3
     - spec: spectrum-mpi@10.3.1.03rtm0%clang@9.0.0
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-9.0.0
-    - spec: spectrum-mpi@10.3.1.03rtm0%clang@9.0.0ibm
+    - spec: spectrum-mpi@10.3.1.03rtm0%clang@9.0.0-ibm
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-ibm-2019.10.03
-    - spec: spectrum-mpi@10.3.1.03rtm0%clang@10.0.1ibm
+    - spec: spectrum-mpi@10.3.1.03rtm0%clang@10.0.1-ibm
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-ibm-10.0.1
     - spec: spectrum-mpi@10.3.1.03rtm0%xl@16.1.1.7
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2020.03.18


### PR DESCRIPTION
"clang@9.0.0ibm" gets confused with the other variation "clang@9.0.0" - adding the dash removes the confusion between versions of clang