### PR TITLE
Add required version to cmake specs for toss packages (Fixes #23)

### DIFF
--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -1,4 +1,4 @@
-compilers:
+compilers::
 - compiler:
     spec: clang@3.9.1
     paths:

--- a/toss_3_x86_64_ib/packages.yaml
+++ b/toss_3_x86_64_ib/packages.yaml
@@ -1,4 +1,4 @@
-packages:
+packages::
   all:
     # This defaults us to machine specific flags of ivybridge which allows
     # us to run on broadwell as well
@@ -9,7 +9,7 @@ packages:
     buildable: false
 
     externals:
-    - spec: cmake
+    - spec: cmake@3.14.5
       prefix: /usr/tce/packages/cmake/cmake-3.14.5
   cuda:
     version: [10.1.168]

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -1,4 +1,4 @@
-compilers:
+compilers::
 - compiler:
     spec: cce@12.0.3
     paths:

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -1,4 +1,4 @@
-packages:
+packages::
   all:
     # This defaults us to machine specific flags of ivybridge which allows
     # us to run on broadwell as well
@@ -9,7 +9,7 @@ packages:
     buildable: false
 
     externals:
-    - spec: cmake
+    - spec: cmake@3.14.5
       prefix: /usr/tce/packages/cmake/cmake-3.14.5
   cuda:
     version: [11.4.120]


### PR DESCRIPTION
Fixes #23 

As mentioned in the issue, the spec version is required in `packages.yaml` so this PR adds it.  Otherwise, `spack install` fails with:

==> Error: Spec version is not concrete: cmake

I also added the scope override notation -- double colons -- so my personal configuration scope does take precedence for these files.  See https://spack.readthedocs.io/en/latest/configuration.html#overriding-entire-sections for more information.