### PR TITLE
bump hip to 5.1.1 to fix corona

### DIFF
--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -2,10 +2,10 @@ compilers::
 - compiler:
     spec: clang@13.0.0
     paths:
-      cc: /opt/rocm-5.1.0/llvm/bin/amdclang
-      cxx: /opt/rocm-5.1.0/llvm/bin/amdclang++
-      f77: /opt/rocm-5.1.0/llvm/bin/amdflang
-      fc: /opt/rocm-5.1.0/llvm/bin/amdflang
+      cc: /opt/rocm-5.1.1/llvm/bin/amdclang
+      cxx: /opt/rocm-5.1.1/llvm/bin/amdclang++
+      f77: /opt/rocm-5.1.1/llvm/bin/amdflang
+      fc: /opt/rocm-5.1.1/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64 

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -19,7 +19,7 @@ packages::
     - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
   hip:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.0]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
     buildable: false
     externals:
     - spec: hip@4.3.1
@@ -28,10 +28,10 @@ packages::
       prefix: /opt/rocm-4.5.2/hip
     - spec: hip@5.0.2
       prefix: /opt/rocm-5.0.2/hip
-    - spec: hip@5.1.0
-      prefix: /opt/rocm-5.1.0/hip
+    - spec: hip@5.1.1
+      prefix: /opt/rocm-5.1.1/hip
   llvm-amdgpu:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.0]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
     buildable: false
     externals:
     - spec: llvm-amdgpu@4.3.1
@@ -40,10 +40,10 @@ packages::
       prefix: /opt/rocm-4.5.2/llvm
     - spec: llvm-amdgpu@5.0.2
       prefix: /opt/rocm-5.0.2/llvm
-    - spec: llvm-amdgpu@5.1.0
-      prefix: /opt/rocm-5.1.0/llvm
+    - spec: llvm-amdgpu@5.1.1
+      prefix: /opt/rocm-5.1.1/llvm
   hsa-rocr-dev:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.0]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@4.3.1
@@ -52,10 +52,10 @@ packages::
       prefix: /opt/rocm-4.5.2/
     - spec: hsa-rocr-dev@5.0.2
       prefix: /opt/rocm-5.0.2/
-    - spec: hsa-rocr-dev@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: hsa-rocr-dev@5.1.1
+      prefix: /opt/rocm-5.1.1/
   rocminfo:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.0]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
     buildable: false
     externals:
     - spec: rocminfo@4.3.1
@@ -64,10 +64,10 @@ packages::
       prefix: /opt/rocm-4.5.2/
     - spec: rocminfo@5.0.2
       prefix: /opt/rocm-5.0.2/
-    - spec: rocminfo@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: rocminfo@5.1.1
+      prefix: /opt/rocm-5.1.1/
   rocm-device-libs:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.0]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
     buildable: false
     externals:
     - spec: rocm-device-libs@4.3.1
@@ -76,14 +76,14 @@ packages::
       prefix: /opt/rocm-4.5.2/
     - spec: rocm-device-libs@5.0.2
       prefix: /opt/rocm-5.0.2/
-    - spec: rocm-device-libs@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: rocm-device-libs@5.1.1
+      prefix: /opt/rocm-5.1.1/
   rocprim:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: rocprim@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: rocprim@5.1.1
+      prefix: /opt/rocm-5.1.1/
   mvapich2:
     externals:
     - spec: mvapich2@2.3.6%gcc@10.2.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32


### PR DESCRIPTION
After the TCE update the 5.1.0 rocm is no longer available on corona,
but both corona and tioga have 5.1.1, so hopefully this will unblock us.