### PR TITLE
Woptim/spack v0.19.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -190,10 +190,20 @@ config:
   package_lock_timeout: null
 
 
-  # Control whether Spack embeds RPATH or RUNPATH attributes in ELF binaries.
-  # Has no effect on macOS. DO NOT MIX these within the same install tree.
-  # See the Spack documentation for details.
-  shared_linking: 'rpath'
+  # Control how shared libraries are located at runtime on Linux. See the
+  # the Spack documentation for details.
+  shared_linking:
+    # Spack automatically embeds runtime search paths in ELF binaries for their
+    # dependencies. Their type can either be "rpath" or "runpath". For glibc, rpath is
+    # inherited and has precedence over LD_LIBRARY_PATH; runpath is not inherited
+    # and of lower precedence. DO NOT MIX these within the same install tree.
+    type: rpath
+
+
+    # (Experimental) Embed absolute paths of dependent libraries directly in ELF
+    # binaries to avoid runtime search. This can improve startup time of
+    # executables with many dependencies, in particular on slow filesystems.
+    bind: false
 
 
   # Set to 'false' to allow installation on filesystems that doesn't allow setgid bit
@@ -204,3 +214,7 @@ config:
   # building and installing packages. This gives information about Spack's
   # current progress as well as the current and total number of packages.
   terminal_title: false
+
+  # Number of seconds a buildcache's index.json is cached locally before probing
+  # for updates, within a single Spack invocation. Defaults to 10 minutes.
+  binary_index_ttl: 600

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -27,59 +27,71 @@ packages::
     - spec: cuda@11.4.120
       prefix: /opt/toss/cudatoolkit/11.4/ 
   hip:
-    version: [4.5.2, 5.0.2, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
     buildable: false
     externals:
     - spec: hip@4.5.2
       prefix: /opt/rocm-4.5.2/hip
     - spec: hip@5.0.2
       prefix: /opt/rocm-5.0.2/hip
+    - spec: hip@5.2.3
+      prefix: /opt/rocm-5.2.3/hip
     - spec: hip@5.3.0
       prefix: /opt/rocm-5.3.0/hip
   llvm-amdgpu:
-    version: [4.5.2, 5.0.2, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
     buildable: false
     externals:
     - spec: llvm-amdgpu@4.5.2
       prefix: /opt/rocm-4.5.2/llvm
     - spec: llvm-amdgpu@5.0.2
       prefix: /opt/rocm-5.0.2/llvm
+    - spec: llvm-amdgpu@5.2.3
+      prefix: /opt/rocm-5.2.3/llvm
     - spec: llvm-amdgpu@5.3.0
       prefix: /opt/rocm-5.3.0/llvm
   hsa-rocr-dev:
-    version: [4.5.2, 5.0.2, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@4.5.2
       prefix: /opt/rocm-4.5.2/
     - spec: hsa-rocr-dev@5.0.2
       prefix: /opt/rocm-5.0.2/
+    - spec: hsa-rocr-dev@5.2.3
+      prefix: /opt/rocm-5.2.3/
     - spec: hsa-rocr-dev@5.3.0
       prefix: /opt/rocm-5.3.0/
   rocminfo:
-    version: [4.5.2, 5.0.2, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
     buildable: false
     externals:
     - spec: rocminfo@4.5.2
       prefix: /opt/rocm-4.5.2/
     - spec: rocminfo@5.0.2
       prefix: /opt/rocm-5.0.2/
+    - spec: rocminfo@5.2.3
+      prefix: /opt/rocm-5.2.3/
     - spec: rocminfo@5.3.0
       prefix: /opt/rocm-5.3.0/
   rocm-device-libs:
-    version: [4.5.2, 5.0.2, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
     buildable: false
     externals:
     - spec: rocm-device-libs@4.5.2
       prefix: /opt/rocm-4.5.2/
     - spec: rocm-device-libs@5.0.2
       prefix: /opt/rocm-5.0.2/
+    - spec: rocm-device-libs@5.2.3
+      prefix: /opt/rocm-5.2.3/
     - spec: rocm-device-libs@5.3.0
       prefix: /opt/rocm-5.3.0/
   rocprim:
-    version: [5.3.0]
+    version: [5.2.3, 5.3.0]
     buildable: false
     externals:
+    - spec: rocprim@5.2.3
+      prefix: /opt/rocm-5.2.3/
     - spec: rocprim@5.3.0
       prefix: /opt/rocm-5.3.0/
   cray_mpich:

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -76,6 +76,12 @@ packages::
       prefix: /opt/rocm-5.0.2/
     - spec: rocm-device-libs@5.3.0
       prefix: /opt/rocm-5.3.0/
+  rocprim:
+    version: [5.3.0]
+    buildable: false
+    externals:
+    - spec: rocprim@5.3.0
+      prefix: /opt/rocm-5.3.0/
   cray_mpich:
     externals:
     - spec: cray_mpich@8.1.9%gcc@10.2.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32


### PR DESCRIPTION
This PR adds

- *breaking changes* to support spack@v0.19.0
- rocprim external install
- rocm@5.2.3 version, since codes are having issues with rocm@5.3.0 (see https://github.com/LLNL/radiuss-shared-ci/issues/15)