### PR TITLE
Task/compiler updates

### DIFF
--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -104,6 +104,19 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@15.0.6
+    paths:
+      cc: /usr/tce/packages/clang/clang-15.0.6/bin/clang
+      cxx: /usr/tce/packages/clang/clang-15.0.6/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@ibm.9.0.0
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang
@@ -182,6 +195,19 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@ibm.15.0.6
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@coral2018.08.08
     paths:
       cc: /usr/tce/packages/clang/clang-coral-2018.08.08/bin/clang
@@ -208,12 +234,12 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.3.1
+    spec: gcc@default
     paths:
-      cc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      cc: gcc
+      cxx: g++
+      f77: gfortran
+      fc: gfortran
     flags: {}
     operating_system: rhel7
     target: ppc64le
@@ -234,12 +260,12 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@default
+    spec: gcc@8.3.1
     paths:
-      cc: gcc
-      cxx: g++
-      f77: gfortran
-      fc: gfortran
+      cc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
     flags: {}
     operating_system: rhel7
     target: ppc64le
@@ -344,6 +370,32 @@ compilers:
       cxx: /usr/tce/packages/pgi/pgi-20.4/bin/pgc++
       f77: /usr/tce/packages/pgi/pgi-20.4/bin/pgfortran
       fc: /usr/tce/packages/pgi/pgi-20.4/bin/pgf90
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@21.11
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-21.11/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-21.11/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-21.11/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-21.11/bin/pgf90
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@22.11
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-22.11/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-22.11/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-22.11/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-22.11/bin/pgf90
     flags: {}
     operating_system: rhel7
     target: ppc64le

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -23,9 +23,11 @@ packages:
     - spec: cmake@3.23.1
       prefix: /usr/tce/packages/cmake/cmake-3.23.1
   cuda:
-    version: [11.7.0, 11.5.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
+    version: [12.0.0, 11.7.0, 11.5.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
     externals:
+    - spec: cuda@12.0.0~allow-unsupported-compilers
+      prefix: /usr/tce/packages/cuda/cuda-12.0.0
     - spec: cuda@11.7.0~allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.7.0
     - spec: cuda@11.5.0~allow-unsupported-compilers

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -39,6 +39,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@8.0.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-8.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-8.0.0/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@9.0.0
     paths:
       cc: /usr/tce/packages/clang/clang-9.0.0/bin/clang
@@ -65,12 +78,155 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@11.0.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-11.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-11.0.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@12.0.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-12.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-12.0.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@13.0.0
+    paths:
+      cc: /usr/tce/packages/clang/clang-13.0.0/bin/clang
+      cxx: /usr/tce/packages/clang/clang-13.0.0/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@14.0.4
+    paths:
+      cc: /usr/tce/packages/clang/clang-14.0.4/bin/clang
+      cxx: /usr/tce/packages/clang/clang-14.0.4/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@4.9.3
     paths:
       cc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gcc
       cxx: /usr/tce/packages/gcc/gcc-4.9.3/bin/g++
       f77: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
       fc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@6.1.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-6.1.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.1.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.3.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.1.0
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.3.1
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@9.3.1
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-9.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-9.3.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-9.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-9.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@10.2.1
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-10.2.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-10.2.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-10.2.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-10.2.1/bin/gfortran
     flags: {}
     operating_system: rhel7
     target: x86_64
@@ -174,6 +330,38 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: intel@19.1.2
+    paths:
+      cc: /usr/tce/packages/intel/intel-19.1.2/bin/icc
+      cxx: /usr/tce/packages/intel/intel-19.1.2/bin/icpc
+      f77: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
+      fc: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@2022.3
+    paths:
+      cc: /usr/tce/packages/intel/intel-2022.3/bin/icc
+      cxx: /usr/tce/packages/intel/intel-2022.3/bin/icpc
+      f77: /usr/tce/packages/intel/intel-2022.3/bin/ifort
+      fc: /usr/tce/packages/intel/intel-2022.3/bin/ifort
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@17.10
     paths:
       cc: /usr/tce/packages/pgi/pgi-17.10/bin/pgcc
@@ -239,12 +427,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@6.1.0
+    spec: pgi@21.1
     paths:
-      cc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-6.1.0/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran
+      cc: /usr/tce/packages/pgi/pgi-21.1/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-21.1/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-21.1/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-21.1/bin/pgf95
     flags: {}
     operating_system: rhel7
     target: x86_64
@@ -252,77 +440,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@7.1.0
+    spec: pgi@22.1
     paths:
-      cc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-7.1.0/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@7.3.0
-    paths:
-      cc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-7.3.0/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.3.1
-    paths:
-      cc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.3.1
-    paths:
-      cc: /usr/tce/packages/gcc/gcc-9.3.1/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-9.3.1/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-9.3.1/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-9.3.1/bin/gfortran
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@10.2.1
-    paths:
-      cc: /usr/tce/packages/gcc/gcc-10.2.1/bin/gcc
-      cxx: /usr/tce/packages/gcc/gcc-10.2.1/bin/g++
-      f77: /usr/tce/packages/gcc/gcc-10.2.1/bin/gfortran
-      fc: /usr/tce/packages/gcc/gcc-10.2.1/bin/gfortran
+      cc: /usr/tce/packages/pgi/pgi-22.1/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-22.1/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-22.1/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-22.1/bin/pgf95
     flags: {}
     operating_system: rhel7
     target: x86_64

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -41,8 +41,8 @@ compilers::
 - compiler:
     spec: clang@8.0.1
     paths:
-      cc: /usr/tce/packages/clang/clang-8.0.0/bin/clang
-      cxx: /usr/tce/packages/clang/clang-8.0.0/bin/clang++
+      cc: /usr/tce/packages/clang/clang-8.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-8.0.1/bin/clang++
       f77: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
       fc: /usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran
     flags: {}

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -362,6 +362,38 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: oneapi@2022.2
+    paths:
+      cc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icx
+      cxx: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icpx
+      f77: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
+      fc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2022.3
+    paths:
+      cc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icx
+      cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
+      f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
+      fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@17.10
     paths:
       cc: /usr/tce/packages/pgi/pgi-17.10/bin/pgcc

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -13,6 +13,32 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@14.0.0
+    paths:
+      cc: /opt/rocm-5.2.3/llvm/bin/amdclang
+      cxx: /opt/rocm-5.2.3/llvm/bin/amdclang++
+      f77: /opt/rocm-5.2.3/llvm/bin/amdflang
+      fc: /opt/rocm-5.2.3/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@15.0.0
+    paths:
+      cc: /opt/rocm-5.4.1/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.1/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.1/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.1/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@20.4
     paths:
       cc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgcc
@@ -28,10 +54,10 @@ compilers::
 - compiler:
     spec: gcc@10.3.1
     paths:
-      cc: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gcc
-      cxx: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/g++
-      f77: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gfortran
-      fc: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gfortran
+      cc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/g++
+      f77: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -25,7 +25,7 @@ packages::
     - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
   hip:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: hip@4.3.1
@@ -36,8 +36,12 @@ packages::
       prefix: /opt/rocm-5.0.2/hip
     - spec: hip@5.1.1
       prefix: /opt/rocm-5.1.1/hip
+    - spec: hip@5.2.3
+      prefix: /opt/rocm-5.2.3/hip
+    - spec: hip@5.4.1
+      prefix: /opt/rocm-5.4.1/hip
   llvm-amdgpu:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: llvm-amdgpu@4.3.1
@@ -48,8 +52,12 @@ packages::
       prefix: /opt/rocm-5.0.2/llvm
     - spec: llvm-amdgpu@5.1.1
       prefix: /opt/rocm-5.1.1/llvm
+    - spec: llvm-amdgpu@5.2.3
+      prefix: /opt/rocm-5.2.3/llvm
+    - spec: llvm-amdgpu@5.4.1
+      prefix: /opt/rocm-5.4.1/llvm
   hsa-rocr-dev:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@4.3.1
@@ -60,8 +68,12 @@ packages::
       prefix: /opt/rocm-5.0.2/
     - spec: hsa-rocr-dev@5.1.1
       prefix: /opt/rocm-5.1.1/
+    - spec: hsa-rocr-dev@5.2.3
+      prefix: /opt/rocm-5.2.3/
+    - spec: hsa-rocr-dev@5.4.1
+      prefix: /opt/rocm-5.4.1/
   rocminfo:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: rocminfo@4.3.1
@@ -72,8 +84,12 @@ packages::
       prefix: /opt/rocm-5.0.2/
     - spec: rocminfo@5.1.1
       prefix: /opt/rocm-5.1.1/
+    - spec: rocminfo@5.2.3
+      prefix: /opt/rocm-5.2.3/
+    - spec: rocminfo@5.4.1
+      prefix: /opt/rocm-5.4.1/
   rocm-device-libs:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1]
+    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: rocm-device-libs@4.3.1
@@ -84,15 +100,23 @@ packages::
       prefix: /opt/rocm-5.0.2/
     - spec: rocm-device-libs@5.1.1
       prefix: /opt/rocm-5.1.1/
+    - spec: rocm-device-libs@5.2.3
+      prefix: /opt/rocm-5.2.3/
+    - spec: rocm-device-libs@5.4.1
+      prefix: /opt/rocm-5.4.1/
   rocprim:
-    version: [5.1.1]
+    version: [5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
     - spec: rocprim@5.1.1
       prefix: /opt/rocm-5.1.1/
+    - spec: rocprim@5.2.3
+      prefix: /opt/rocm-5.2.3/
+    - spec: rocprim@5.4.1
+      prefix: /opt/rocm-5.4.1/
   mvapich2:
     externals:
-    - spec: mvapich2@2.3.6%gcc@10.2.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.6%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
-      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.2.1 
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1 
     buildable: false

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -39,7 +39,20 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@11.0.0
+    spec: cce@15.0.0
+    paths:
+      cc: /usr/tce/packages/cce-tce/cce-15.0.0/bin/craycc
+      cxx: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayCC
+      f77: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayftn
+      fc: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayftn
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@13.0.1
     paths:
       cc: /usr/bin/clang
       cxx: /usr/bin/clang++
@@ -52,7 +65,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.4.1
+    spec: gcc@8.5.0
     paths:
       cc: /usr/bin/gcc
       cxx: /usr/bin/g++
@@ -65,12 +78,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@10.2.1
+    spec: gcc@10.3.1
     paths:
-      cc: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gcc
-      cxx: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/g++
-      f77: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gfortran
-      fc: /usr/tce/packages/gcc-tce/gcc-10.2.1/bin/gfortran
+      cc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/g++
+      f77: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
     flags: {}
     operating_system: rhel8
     target: x86_64


### PR DESCRIPTION
I added new specs based on what is now available on the various testing platforms and corrected a few things where specified versions do not exist.

Questions I have:

- Trying to test some of these new specs manually in RAJA through uberenv, it appears that the new spack we are using (0.19.0)  no longer likes it when you set compiler flags on the command line spec. Is there a new quote-related syntax to use? These flags are set in the compilers.yml file. It would be nice to be able to test different versions of gcc headers with the same compiler, for example.
- The oneapi stuff works when I use it with a host-config file that I manually created. However, through uberenv/spack, it runs into an issue building camp. It looks like the proper gcc headers are not being used in the camp build, but not 100% sure.
- For toss4 (corona) specs, we label the specs based on clang version, not rocm version. Multiple rocm versions report the same clang version for amdclang++. Is there a way to change the specs to be named for rocm version, so we can test if needed?
- SImilarly, for blueos, multipl xl compiler drops, labeled by date, report the same xl compiler version. Is there a way to distinguish by drop date instead of cl version number. For example, 2022.06.25 and 2022.08.19 both report XL Version: 16.01.0001.0012. How can we distinguish?