### PR TITLE
Update specs for new set of radiuss shared ci configs

### DIFF
--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -418,6 +418,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: xl@16.1.1.12.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlc_r
+      cxx: /usr/tce/packages/xl/xl-2022.08.19/bin/xlC_r
+      fc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@default
     paths:
       cc: pgcc

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -117,7 +117,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.9.0.0
+    spec: clang@9.0.0.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-2019.10.03/bin/clang++
@@ -130,7 +130,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.10.0.1
+    spec: clang@10.0.1.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-10.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-10.0.1/bin/clang++
@@ -143,7 +143,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.11.0.0
+    spec: clang@11.0.0.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-11.0.0/bin/clang++
@@ -156,7 +156,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.12.0.1
+    spec: clang@12.0.1.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
@@ -169,7 +169,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.13.0.1
+    spec: clang@13.0.1.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-13.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-13.0.1/bin/clang++
@@ -182,7 +182,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.14.0.5
+    spec: clang@14.0.5.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
@@ -195,7 +195,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@ibm.15.0.6
+    spec: clang@15.0.6.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang++
@@ -327,10 +327,10 @@ compilers:
 - compiler:
     spec: xl@16.1.1.12
     paths:
-      cc: /usr/tce/packages/xl/xl-2022.03.10/bin/xlc_r
-      cxx: /usr/tce/packages/xl/xl-2022.03.10/bin/xlC_r
-      fc: /usr/tce/packages/xl/xl-2021.12.22/bin/xlf2003_r
-      f77: /usr/tce/packages/xl/xl-2021.12.22/bin/xlf_r
+      cc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlc_r
+      cxx: /usr/tce/packages/xl/xl-2022.08.19/bin/xlC_r
+      fc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf_r
     flags: {}
     operating_system: rhel7
     target: ppc64le

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -78,7 +78,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1.gcc.8.3.1
+    spec: clang@12.0.1gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-12.0.1/bin/clang++
@@ -107,7 +107,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@13.0.1.gcc.8.3.1
+    spec: clang@13.0.1gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-13.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-13.0.1/bin/clang++
@@ -136,7 +136,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5.gcc.8.3.1
+    spec: clang@14.0.5gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-14.0.5/bin/clang++
@@ -204,7 +204,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1.ibm
+    spec: clang@12.0.1ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
@@ -217,7 +217,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1.ibm.gcc.8.3.1
+    spec: clang@12.0.1ibmgcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
@@ -246,7 +246,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5.ibm
+    spec: clang@14.0.5ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
@@ -259,7 +259,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5.ibm.gcc.8.3.1
+    spec: clang@14.0.5ibmgcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
@@ -418,7 +418,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: xl@16.1.1.12.gcc.8.3.1
+    spec: xl@16.1.1.12gcc.8.3.1
     paths:
       cc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlc_r
       cxx: /usr/tce/packages/xl/xl-2022.08.19/bin/xlC_r

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -201,6 +201,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@12.0.1.ibm.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@13.0.1.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-13.0.1/bin/clang
@@ -221,6 +237,22 @@ compilers:
       fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
       f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
     flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@14.0.5.ibm.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: ppc64le
     modules: []

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -250,8 +250,8 @@ compilers:
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
-      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
-      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+      fc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf_r
     flags: {}
     operating_system: rhel7
     target: ppc64le
@@ -263,8 +263,8 @@ compilers:
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
-      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
-      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+      fc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2022.08.19/bin/xlf_r
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -78,6 +78,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@12.0.1.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-12.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-12.0.1/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@13.0.1
     paths:
       cc: /usr/tce/packages/clang/clang-13.0.1/bin/clang
@@ -98,6 +114,22 @@ compilers:
       fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
       f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
     flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@14.0.5.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-14.0.5/bin/clang
+      cxx: /usr/tce/packages/clang/clang-14.0.5/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: ppc64le
     modules: []

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -107,6 +107,22 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@13.0.1.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-13.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-13.0.1/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@14.0.5
     paths:
       cc: /usr/tce/packages/clang/clang-14.0.5/bin/clang

--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -78,7 +78,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1gcc.8.3.1
+    spec: clang@12.0.1.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-12.0.1/bin/clang++
@@ -107,7 +107,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@13.0.1gcc.8.3.1
+    spec: clang@13.0.1.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-13.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-13.0.1/bin/clang++
@@ -136,7 +136,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5gcc.8.3.1
+    spec: clang@14.0.5.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-14.0.5/bin/clang++
@@ -204,7 +204,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1ibm
+    spec: clang@12.0.1.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
@@ -217,7 +217,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@12.0.1ibmgcc.8.3.1
+    spec: clang@12.0.1.ibm.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-12.0.1/bin/clang++
@@ -246,7 +246,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5ibm
+    spec: clang@14.0.5.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
@@ -259,7 +259,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.5ibmgcc.8.3.1
+    spec: clang@14.0.5.ibm.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
       cxx: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang++
@@ -418,7 +418,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: xl@16.1.1.12gcc.8.3.1
+    spec: xl@16.1.1.12.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/xl/xl-2022.08.19/bin/xlc_r
       cxx: /usr/tce/packages/xl/xl-2022.08.19/bin/xlC_r

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -26,27 +26,27 @@ packages:
     version: [12.0.0, 11.7.0, 11.5.0, 11.2.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
     externals:
-    - spec: cuda@12.0.0+allow-unsupported-compilers
+    - spec: cuda@12.0.0
       prefix: /usr/tce/packages/cuda/cuda-12.0.0
-    - spec: cuda@11.7.0+allow-unsupported-compilers
+    - spec: cuda@11.7.0
       prefix: /usr/tce/packages/cuda/cuda-11.7.0
-    - spec: cuda@11.5.0+allow-unsupported-compilers
+    - spec: cuda@11.5.0
       prefix: /usr/tce/packages/cuda/cuda-11.5.0
-    - spec: cuda@11.2.0+allow-unsupported-compilers
+    - spec: cuda@11.2.0
       prefix: /usr/tce/packages/cuda/cuda-11.2.0
-    - spec: cuda@11.1.0+allow-unsupported-compilers
+    - spec: cuda@11.1.0
       prefix: /usr/tce/packages/cuda/cuda-11.1.0
-    - spec: cuda@11.0.2+allow-unsupported-compilers
+    - spec: cuda@11.0.2
       prefix: /usr/tce/packages/cuda/cuda-11.0.2
-    - spec: cuda@10.2.89+allow-unsupported-compilers
+    - spec: cuda@10.2.89
       prefix: /usr/tce/packages/cuda/cuda-10.2.89
-    - spec: cuda@10.1.243+allow-unsupported-compilers
+    - spec: cuda@10.1.243
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
-    - spec: cuda@10.1.168+allow-unsupported-compilers
+    - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
-    - spec: cuda@9.2.148+allow-unsupported-compilers
+    - spec: cuda@9.2.148
       prefix: /usr/tce/packages/cuda/cuda-9.2.148
-    - spec: cuda@8.0+allow-unsupported-compilers
+    - spec: cuda@8.0
       prefix: /usr/tce/packages/cuda/cuda-8.0
   spectrum-mpi:
     externals:

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -23,7 +23,7 @@ packages:
     - spec: cmake@3.23.1
       prefix: /usr/tce/packages/cmake/cmake-3.23.1
   cuda:
-    version: [12.0.0, 11.7.0, 11.5.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
+    version: [12.0.0, 11.7.0, 11.5.0, 11.2.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
     externals:
     - spec: cuda@12.0.0~allow-unsupported-compilers
@@ -32,6 +32,8 @@ packages:
       prefix: /usr/tce/packages/cuda/cuda-11.7.0
     - spec: cuda@11.5.0~allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.5.0
+    - spec: cuda@11.2.0~allow-unsupported-compilers
+      prefix: /usr/tce/packages/cuda/cuda-11.2.0
     - spec: cuda@11.1.0~allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.1.0
     - spec: cuda@11.0.2~allow-unsupported-compilers

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -26,27 +26,27 @@ packages:
     version: [12.0.0, 11.7.0, 11.5.0, 11.2.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
     externals:
-    - spec: cuda@12.0.0
+    - spec: cuda@12.0.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-12.0.0
-    - spec: cuda@11.7.0
+    - spec: cuda@11.7.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.7.0
-    - spec: cuda@11.5.0
+    - spec: cuda@11.5.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.5.0
-    - spec: cuda@11.2.0
+    - spec: cuda@11.2.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.2.0
-    - spec: cuda@11.1.0
+    - spec: cuda@11.1.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.1.0
-    - spec: cuda@11.0.2
+    - spec: cuda@11.0.2+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.0.2
-    - spec: cuda@10.2.89
+    - spec: cuda@10.2.89+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.2.89
-    - spec: cuda@10.1.243
+    - spec: cuda@10.1.243+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
-    - spec: cuda@10.1.168
+    - spec: cuda@10.1.168+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
-    - spec: cuda@9.2.148
+    - spec: cuda@9.2.148+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-9.2.148
-    - spec: cuda@8.0
+    - spec: cuda@8.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-8.0
   spectrum-mpi:
     externals:

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -26,27 +26,27 @@ packages:
     version: [12.0.0, 11.7.0, 11.5.0, 11.2.0, 11.1.0, 11.0.2, 10.2.89, 10.1.243, 10.1.168, 9.2.148, 8.0]
     buildable: false
     externals:
-    - spec: cuda@12.0.0~allow-unsupported-compilers
+    - spec: cuda@12.0.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-12.0.0
-    - spec: cuda@11.7.0~allow-unsupported-compilers
+    - spec: cuda@11.7.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.7.0
-    - spec: cuda@11.5.0~allow-unsupported-compilers
+    - spec: cuda@11.5.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.5.0
-    - spec: cuda@11.2.0~allow-unsupported-compilers
+    - spec: cuda@11.2.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.2.0
-    - spec: cuda@11.1.0~allow-unsupported-compilers
+    - spec: cuda@11.1.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.1.0
-    - spec: cuda@11.0.2~allow-unsupported-compilers
+    - spec: cuda@11.0.2+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.0.2
-    - spec: cuda@10.2.89~allow-unsupported-compilers
+    - spec: cuda@10.2.89+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.2.89
-    - spec: cuda@10.1.243~allow-unsupported-compilers
+    - spec: cuda@10.1.243+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
-    - spec: cuda@10.1.168~allow-unsupported-compilers
+    - spec: cuda@10.1.168+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
-    - spec: cuda@9.2.148~allow-unsupported-compilers
+    - spec: cuda@9.2.148+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-9.2.148
-    - spec: cuda@8.0~allow-unsupported-compilers
+    - spec: cuda@8.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-8.0
   spectrum-mpi:
     externals:

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -103,7 +103,7 @@ def blt_link_helpers(options, spec, spec_compiler):
         options.append(cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
         "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
-    compilers_using_toolchain = ["pgi", "xl", "icpc"]
+    compilers_using_toolchain = ["pgc++", "xlc++", "xlC_r", "icpc", "clang++", "icpx"]
     if any(compiler in spec_compiler.cxx for compiler in compilers_using_toolchain):
         if spec_uses_toolchain(spec) or spec_uses_gccname(spec):
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -7,8 +7,6 @@ import os
 import socket
 import glob
 import re
-## Solution A
-#import spack.variant
 
 from spack.package import *
 from spack.pkg.builtin.camp import hip_for_radiuss_projects
@@ -71,37 +69,6 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant("tests", default=False, description="Build tests")
 
-    ## Solution A:
-    ## We set the variant so that it can take any combination of the tests known as
-    ## potentially failing. This allows flexibility, ignored test are visible in the
-    ## spec. However the list of test may be long, and by default the failing tests
-    ## are not ignored
-    #tests_that_may_fail = (
-    #    "test-algorithm-sort-Cuda.exe",
-    #    "test-algorithm-stable-sort-Cuda.exe")
-    #
-    #variant(
-    #    "ignore-test",
-    #    description="List of tests to ignore",
-    #    value=spack.variant.any_combination_of(*tests_that_may_fail))
-
-    ## Solution B:
-    ## We set the variant value conditionally, the tests in the variant value will
-    ## be ignored when the conditions are met.
-    ## The only advantage of that is make the ignored tests visible in the spec.
-    ## Not sure that’s worth the mess.
-    #variant(
-    #    "ignore-test",
-    #    values=("none",
-    #            conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
-    #                        when="+cuda %clang@12.0.0:13.9.999")),
-    #            conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
-    #                        when="+cuda %xl@16.1.1.12")),
-    #    multi=False,
-    #    description="Do not ignore tests known to fail"
-    #    )
-
-    ## Solution C:
     ## we don’t use variants to express the failing test, we only add a variant to
     ## define whether we want to run all the tests (including those known to fail)
     ## or only the passing ones.
@@ -283,7 +250,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_TESTS", True))
             if not "+run-all-tests" in spec:
                 if spec.satisfies("+cuda %clang@12.0.0:13.9.999"):
-                    entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe;test-algorithm-sort-OpenMP.exe;test-algorithm-stable-sort-OpenMP.exe"))
                 if spec.satisfies("+cuda %xl@16.1.1.12"):
                     entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -7,6 +7,8 @@ import os
 import socket
 import glob
 import re
+## Solution A
+#import spack.variant
 
 from spack.package import *
 from spack.pkg.builtin.camp import hip_for_radiuss_projects
@@ -59,14 +61,51 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     variant("openmp", default=True, description="Build OpenMP backend")
     variant("shared", default=True, description="Build shared libs")
+    variant("libcpp", default=False, description="Uses libc++ instead of libstdc++")
+    variant("desul", default=False, description="Build desul atomics backend")
+    variant("vectorization", default=True, description="Build SIMD/SIMT intrinsics support")
+
     variant("examples", default=True, description="Build examples.")
     variant("exercises", default=True, description="Build exercises.")
     # TODO: figure out gtest dependency and then set this default True
     # and remove the +tests conflict below.
     variant("tests", default=False, description="Build tests")
-    variant("libcpp", default=False, description="Uses libc++ instead of libstdc++")
-    variant("desul", default=False, description="Build desul atomics backend")
-    variant("vectorization", default=True, description="Build SIMD/SIMT intrinsics support")
+
+    ## Solution A:
+    ## We set the variant so that it can take any combination of the tests known as
+    ## potentially failing. This allows flexibility, ignored test are visible in the
+    ## spec. However the list of test may be long, and by default the failing tests
+    ## are not ignored
+    #tests_that_may_fail = (
+    #    "test-algorithm-sort-Cuda.exe",
+    #    "test-algorithm-stable-sort-Cuda.exe")
+    #
+    #variant(
+    #    "ignore-test",
+    #    description="List of tests to ignore",
+    #    value=spack.variant.any_combination_of(*tests_that_may_fail))
+
+    ## Solution B:
+    ## We set the variant value conditionally, the tests in the variant value will
+    ## be ignored when the conditions are met.
+    ## The only advantage of that is make the ignored tests visible in the spec.
+    ## Not sure that’s worth the mess.
+    #variant(
+    #    "ignore-test",
+    #    values=("none",
+    #            conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
+    #                        when="+cuda %clang@12.0.0:13.9.999")),
+    #            conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
+    #                        when="+cuda %xl@16.1.1.12")),
+    #    multi=False,
+    #    description="Do not ignore tests known to fail"
+    #    )
+
+    ## Solution C:
+    ## we don’t use variants to express the failing test, we only add a variant to
+    ## define whether we want to run all the tests (including those known to fail)
+    ## or only the passing ones.
+    variant("run-all-tests", default=False, description="Run all the tests, including those known to fail.")
 
     depends_on("blt")
     depends_on("blt@0.5.2:", type="build", when="@2022.10.0:")
@@ -242,6 +281,11 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_TESTS", False))
         else:
             entries.append(cmake_cache_option("ENABLE_TESTS", True))
+            if not "+run-all-tests" in spec:
+                if spec.satisfies("+cuda %clang@12.0.0:13.9.999"):
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe")
+                if spec.satisfies("+cuda %xl@16.1.1.12"):
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe")
 
         entries.append(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -146,8 +146,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
-        # Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS add
-        # +libcpp specific flags
+        #### BEGIN: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
+        # Goal: add +libcpp specific flags
         flags = spec.compiler_flags
 
         # use global spack compiler flags
@@ -167,6 +167,11 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
         if cxxflags:
             entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
+
+        fflags = " ".join(flags["fflags"])
+        if fflags:
+            entries.append(cmake_cache_string("CMAKE_Fortran_FLAGS", fflags))
+        #### END: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
 
         blt_link_helpers(entries, spec, compiler)
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -283,9 +283,9 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_TESTS", True))
             if not "+run-all-tests" in spec:
                 if spec.satisfies("+cuda %clang@12.0.0:13.9.999"):
-                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
                 if spec.satisfies("+cuda %xl@16.1.1.12"):
-                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
 
         entries.append(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -283,9 +283,9 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_TESTS", True))
             if not "+run-all-tests" in spec:
                 if spec.satisfies("+cuda %clang@12.0.0:13.9.999"):
-                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe")
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
                 if spec.satisfies("+cuda %xl@16.1.1.12"):
-                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe")
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TEST_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe"))
 
         entries.append(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -249,6 +249,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         else:
             entries.append(cmake_cache_option("ENABLE_TESTS", True))
             if not "+run-all-tests" in spec:
+                if spec.satisfies("%clang@12.0.0:13.9.999"):
+                    entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-OpenMP.exe;test-algorithm-stable-sort-OpenMP.exe"))
                 if spec.satisfies("+cuda %clang@12.0.0:13.9.999"):
                     entries.append(cmake_cache_string("CTEST_CUSTOM_TESTS_IGNORE", "test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe;test-algorithm-sort-OpenMP.exe;test-algorithm-stable-sort-OpenMP.exe"))
                 if spec.satisfies("+cuda %xl@16.1.1.12"):

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -191,6 +191,8 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         # Default entries are already defined in CachedCMakePackage, inherit them:
         entries = super(Umpire, self).initconfig_compiler_entries()
 
+
+
         # adrienbernede-22-11:
         #   This was in upstream Spack raja package, but it’s causing the follwing failure:
         #     CMake Error in src/umpire/CMakeLists.txt:
@@ -207,6 +209,33 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_FORTRAN", False))
 
         entries.append(cmake_cache_option("{}ENABLE_C".format(option_prefix), "+c" in spec))
+
+        #### BEGIN: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
+        # Goal: add +libcpp specific flags
+        flags = spec.compiler_flags
+
+        # use global spack compiler flags
+        cppflags = " ".join(flags["cppflags"])
+        if cppflags:
+            # avoid always ending up with " " with no flags defined
+            cppflags += " "
+
+        cflags = cppflags + " ".join(flags["cflags"])
+        if "+libcpp" in spec:
+            cflags += " ".join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
+        if cflags:
+            entries.append(cmake_cache_string("CMAKE_C_FLAGS", cflags))
+
+        cxxflags = cppflags + " ".join(flags["cxxflags"])
+        if "+libcpp" in spec:
+            cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
+        if cxxflags:
+            entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
+
+        fflags = " ".join(flags["fflags"])
+        if fflags:
+            entries.append(cmake_cache_string("CMAKE_Fortran_FLAGS", fflags))
+        #### END: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
 
         blt_link_helpers(entries, spec, compiler)
 

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -113,7 +113,6 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: x86_64
     modules: []

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -104,6 +104,22 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@12.0.1.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-12.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-12.0.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@13.0.0
     paths:
       cc: /usr/tce/packages/clang/clang-13.0.0/bin/clang
@@ -336,6 +352,19 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.1.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.1.2.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/intel/intel-19.1.2/bin/icc
+      cxx: /usr/tce/packages/intel/intel-19.1.2/bin/icpc
+      f77: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
+      fc: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
     flags:
       cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
       cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
@@ -362,7 +391,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: oneapi@2022.2
+    spec: oneapi@2022.2.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icx
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icpx
@@ -379,6 +408,19 @@ compilers::
     extra_rpaths: []
 - compiler:
     spec: oneapi@2022.3
+    paths:
+      cc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icx
+      cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
+      f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
+      fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@2022.3.gcc.8.3.1
     paths:
       cc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icx
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -240,7 +240,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-16.0.4/bin/icpc
       f77: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
       fc: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -253,7 +256,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-17.0.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -266,7 +272,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-18.0.0/bin/icpc
       f77: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
       fc: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -279,7 +288,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-18.0.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -292,7 +304,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.0.4/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -305,7 +320,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.1.0/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -318,7 +336,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.1.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -331,7 +352,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-2022.3/bin/icpc
       f77: /usr/tce/packages/intel/intel-2022.3/bin/ifort
       fc: /usr/tce/packages/intel/intel-2022.3/bin/ifort
-    flags: {}
+    flags:
+      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -344,7 +368,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icpx
       f77: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
       fc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
-    flags: {}
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -357,7 +384,10 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
       f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
       fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-    flags: {}
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: x86_64
     modules: []

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -240,10 +240,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-16.0.4/bin/icpc
       f77: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
       fc: /usr/tce/packages/intel/intel-16.0.4/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -256,10 +253,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-17.0.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-17.0.2/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -272,10 +266,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-18.0.0/bin/icpc
       f77: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
       fc: /usr/tce/packages/intel/intel-18.0.0/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -288,10 +279,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-18.0.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-18.0.2/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.3.0/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -304,10 +292,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.0.4/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.0.4/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-7.1.0/bin/g++
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -320,10 +305,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.1.0/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.1.0/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -336,10 +318,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-19.1.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
       fc: /usr/tce/packages/intel/intel-19.1.2/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -352,10 +331,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-2022.3/bin/icpc
       f77: /usr/tce/packages/intel/intel-2022.3/bin/ifort
       fc: /usr/tce/packages/intel/intel-2022.3/bin/ifort
-    flags:
-      cflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
-      cxxflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++
-      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -368,10 +344,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/icpx
       f77: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
       fc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
-    flags:
-      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -384,10 +357,7 @@ compilers::
       cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
       f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
       fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-    flags:
-      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    flags: {}
     operating_system: rhel7
     target: x86_64
     modules: []

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -514,13 +514,16 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: pgi@22.1
+    spec: pgi@22.1.gcc.local.8.3.1
     paths:
       cc: /usr/tce/packages/pgi/pgi-22.1/bin/pgcc
       cxx: /usr/tce/packages/pgi/pgi-22.1/bin/pgc++
       f77: /usr/tce/packages/pgi/pgi-22.1/bin/pgfortran
       fc: /usr/tce/packages/pgi/pgi-22.1/bin/pgf95
-    flags: {}
+    flags:
+      cflags: -rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc
+      cxxflags: -rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc
+      fflags: -rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc
     operating_system: rhel7
     target: x86_64
     modules: []

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -145,6 +145,21 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@14.0.4.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-14.0.4/bin/clang
+      cxx: /usr/tce/packages/clang/clang-14.0.4/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@4.9.3
     paths:
       cc: /usr/tce/packages/gcc/gcc-4.9.3/bin/gcc

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -116,3 +116,16 @@ compilers::
     modules: []
     environment: {}
     extra_rpaths: []
+- compiler:
+    spec: clang@15.0.0
+    paths:
+      cc: /opt/rocm-5.4.2/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.2/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.2/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.2/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -39,12 +39,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: cce@15.0.0.c
+    spec: cce@15.0.1
     paths:
-      cc: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/craycc
-      cxx: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayCC
-      f77: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayftn
-      fc: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayftn
+      cc: /usr/tce/packages/cce-tce/cce-15.0.1/bin/craycc
+      cxx: /usr/tce/packages/cce-tce/cce-15.0.1/bin/crayCC
+      f77: /usr/tce/packages/cce-tce/cce-15.0.1/bin/crayftn
+      fc: /usr/tce/packages/cce-tce/cce-15.0.1/bin/crayftn
     flags: {}
     operating_system: rhel8
     target: x86_64
@@ -104,7 +104,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@13.0.0
+    spec: clang@13.0.0.rocm.5.3.0
     paths:
       cc: /opt/rocm-5.3.0/llvm/bin/amdclang
       cxx: /opt/rocm-5.3.0/llvm/bin/amdclang++
@@ -117,12 +117,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@15.0.0
+    spec: clang@15.0.0.rocm.5.4.3
     paths:
-      cc: /opt/rocm-5.4.2/llvm/bin/amdclang
-      cxx: /opt/rocm-5.4.2/llvm/bin/amdclang++
-      f77: /opt/rocm-5.4.2/llvm/bin/amdflang
-      fc: /opt/rocm-5.4.2/llvm/bin/amdflang
+      cc: /opt/rocm-5.4.3/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.3/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.3/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.3/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -39,7 +39,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: cce@15.0.0
+    spec: cce@15.0.0.c
     paths:
       cc: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/craycc
       cxx: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayCC

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -41,10 +41,10 @@ compilers::
 - compiler:
     spec: cce@15.0.0
     paths:
-      cc: /usr/tce/packages/cce-tce/cce-15.0.0/bin/craycc
-      cxx: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayCC
-      f77: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayftn
-      fc: /usr/tce/packages/cce-tce/cce-15.0.0/bin/crayftn
+      cc: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/craycc
+      cxx: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayCC
+      f77: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayftn
+      fc: /usr/tce/packages/cce-tce/cce-15.0.0c/bin/crayftn
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -25,9 +25,9 @@ packages::
     buildable: false
     externals:
     - spec: cuda@11.4.120
-      prefix: /opt/toss/cudatoolkit/11.4/ 
+      prefix: /opt/toss/cudatoolkit/11.4/
   hip:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: hip@4.5.2
@@ -38,10 +38,10 @@ packages::
       prefix: /opt/rocm-5.2.3/hip
     - spec: hip@5.3.0
       prefix: /opt/rocm-5.3.0/hip
-    - spec: hip@5.4.2
-      prefix: /opt/rocm-5.4.2/hip
+    - spec: hip@5.4.3
+      prefix: /opt/rocm-5.4.3/hip
   llvm-amdgpu:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: llvm-amdgpu@4.5.2
@@ -52,10 +52,10 @@ packages::
       prefix: /opt/rocm-5.2.3/llvm
     - spec: llvm-amdgpu@5.3.0
       prefix: /opt/rocm-5.3.0/llvm
-    - spec: llvm-amdgpu@5.4.2
-      prefix: /opt/rocm-5.4.2/llvm
+    - spec: llvm-amdgpu@5.4.3
+      prefix: /opt/rocm-5.4.3/llvm
   hsa-rocr-dev:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@4.5.2
@@ -66,10 +66,10 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: hsa-rocr-dev@5.3.0
       prefix: /opt/rocm-5.3.0/
-    - spec: hsa-rocr-dev@5.4.2
-      prefix: /opt/rocm-5.4.2/
+    - spec: hsa-rocr-dev@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocminfo:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: rocminfo@4.5.2
@@ -80,10 +80,10 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: rocminfo@5.3.0
       prefix: /opt/rocm-5.3.0/
-    - spec: rocminfo@5.4.2
-      prefix: /opt/rocm-5.4.2/
+    - spec: rocminfo@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocm-device-libs:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: rocm-device-libs@4.5.2
@@ -94,18 +94,18 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: rocm-device-libs@5.3.0
       prefix: /opt/rocm-5.3.0/
-    - spec: rocm-device-libs@5.4.2
-      prefix: /opt/rocm-5.4.2/
+    - spec: rocm-device-libs@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocprim:
-    version: [5.2.3, 5.3.0, 5.4.2]
+    version: [5.2.3, 5.3.0, 5.4.3]
     buildable: false
     externals:
     - spec: rocprim@5.2.3
       prefix: /opt/rocm-5.2.3/
     - spec: rocprim@5.3.0
       prefix: /opt/rocm-5.3.0/
-    - spec: rocprim@5.4.2
-      prefix: /opt/rocm-5.4.2/
+    - spec: rocprim@5.4.3
+      prefix: /opt/rocm-5.4.3/
   cray_mpich:
     externals:
     - spec: cray_mpich@8.1.9%gcc@10.2.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -27,7 +27,7 @@ packages::
     - spec: cuda@11.4.120
       prefix: /opt/toss/cudatoolkit/11.4/ 
   hip:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: hip@4.5.2
@@ -38,8 +38,10 @@ packages::
       prefix: /opt/rocm-5.2.3/hip
     - spec: hip@5.3.0
       prefix: /opt/rocm-5.3.0/hip
+    - spec: hip@5.4.2
+      prefix: /opt/rocm-5.4.2/hip
   llvm-amdgpu:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: llvm-amdgpu@4.5.2
@@ -50,8 +52,10 @@ packages::
       prefix: /opt/rocm-5.2.3/llvm
     - spec: llvm-amdgpu@5.3.0
       prefix: /opt/rocm-5.3.0/llvm
+    - spec: llvm-amdgpu@5.4.2
+      prefix: /opt/rocm-5.4.2/llvm
   hsa-rocr-dev:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@4.5.2
@@ -62,8 +66,10 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: hsa-rocr-dev@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: hsa-rocr-dev@5.4.2
+      prefix: /opt/rocm-5.4.2/
   rocminfo:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: rocminfo@4.5.2
@@ -74,8 +80,10 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: rocminfo@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: rocminfo@5.4.2
+      prefix: /opt/rocm-5.4.2/
   rocm-device-libs:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: rocm-device-libs@4.5.2
@@ -86,14 +94,18 @@ packages::
       prefix: /opt/rocm-5.2.3/
     - spec: rocm-device-libs@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: rocm-device-libs@5.4.2
+      prefix: /opt/rocm-5.4.2/
   rocprim:
-    version: [5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.2]
     buildable: false
     externals:
     - spec: rocprim@5.2.3
       prefix: /opt/rocm-5.2.3/
     - spec: rocprim@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: rocprim@5.4.2
+      prefix: /opt/rocm-5.4.2/
   cray_mpich:
     externals:
     - spec: cray_mpich@8.1.9%gcc@10.2.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32


### PR DESCRIPTION
Does what the title says... and a little more.

[Adrien’s contribution notes]
In order for the tests to pass, several changes were needed:

## Declare that the system cuda installed allowed unsupported compilers.

  Consequently, we can (and have to) activate the corresponding variant in the CI.
  **Note 1:** If we wanted to mix specs with and without `+allow-unsupported-compilers`
  We’d have to duplicate the external cuda specifications.
  **Note 2:** `~allow-unsupported-compilers` is implicit if unspecified.

## deactivate some tests in specific configurations.

  There are several way we can deactivate tests in RAJA:
  - Google test have a filter option
  - There is a logic inherited from camp in the CMakeFiles to filter test that have special keywords in their source file
  - There is a logic in build-and-test to filter out known-failures with HIP.
  I also wanted to be able to specify the test to ignore at spack level (at list in the package), and that this would be translated as a setting in the hostconfig file (CMakeCache.txt).

In spack, I found several ways to do that, first exploring the variant options:

```
    # Solution A:
    # We set the variant so that it can take any combination of the tests known as
    # potentially failing. This allows flexibility, ignored test are visible in the
    # spec. However the list of test may be long, and by default the failing tests
    # are not ignored
    tests_that_may_fail = (
        "test-algorithm-sort-Cuda.exe",
        "test-algorithm-stable-sort-Cuda.exe")
    
    variant(
        "ignore-test",
        description="List of tests to ignore",
        value=spack.variant.any_combination_of(*tests_that_may_fail))
```

```
    # Solution B:
    # We set the variant value conditionally, the tests in the variant value will
    # be ignored when the conditions are met.
    # The only advantage of that is make the ignored tests visible in the spec.
    # Not sure that’s worth the mess.
    variant(
        "ignore-test",
        values=("none",
                conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
                            when="+cuda %clang@12.0.0:13.9.999")),
                conditional("test-algorithm-sort-Cuda.exe;test-algorithm-stable-sort-Cuda.exe",
                            when="+cuda %xl@16.1.1.12")),
        multi=False,
        description="Do not ignore tests known to fail"
        )
```

```
    # Solution C:
    # we don’t use variants to express the failing test, we only add a variant to
    # define whether we want to run all the tests (including those known to fail)
    # or only the passing ones.
    variant("run-all-tests", default=False, description="Run all the tests, including those known to fail.")
```

I finally gave up on using variants, which would have given messy specs, and opted for solution C. I still wanted to be able to run all the tests, if that sounds futile, let me know.

In the end, the Spack package will set `CTEST_CUSTOM_TESTS_IGNORE` with the list of tests to ignore at the ctest level (a granularity coarser than google tests).