### PR TITLE
adding another conflict rule for umpire device allocators

### DIFF
--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -140,10 +140,13 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("+numa", when="@:0.3.2")
     conflicts("~c", when="+fortran", msg="Fortran API requires C API")
 
+    # device allocator must be used with more current umpire versions, rocm 5.4.0 and greater,
+    # and with either rocm or cuda enabled
     conflicts("+device_alloc", when="@:2022.03.0")
-    conflicts("+deviceconst", when="~rocm~cuda")
+    conflicts("+device_alloc", when="@rocm:5.3.999")
     conflicts("+device_alloc", when="~rocm~cuda")
 
+    conflicts("+deviceconst", when="~rocm~cuda")
     conflicts("~openmp", when="+openmp_target", msg="OpenMP target requires OpenMP")
     conflicts("+cuda", when="+rocm")
     conflicts("+tools", when="+rocm")


### PR DESCRIPTION
Keeping all the device allocator conflict rules together:

1. Must be a recent Umpire version
2. Must be rocm version 5.4.0 and higher -- this is the new one!
3. Must have hip or cuda enabled