### PR TITLE
Updating rocm and compiler versions

### DIFF
--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -143,7 +143,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     # device allocator must be used with more current umpire versions, rocm 5.4.0 and greater,
     # and with either rocm or cuda enabled
     conflicts("+device_alloc", when="@:2022.03.0")
-    conflicts("+device_alloc", when="^rocm@:5.3.99")
+    conflicts("+device_alloc", when="^hip@:5.3.99")
     conflicts("+device_alloc", when="~rocm~cuda")
 
     conflicts("+deviceconst", when="~rocm~cuda")

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -1,6 +1,6 @@
 compilers::
 - compiler:
-    spec: rocm@5.1.1
+    spec: rocmcc@5.1.1
     paths:
       cc: /opt/rocm-5.1.1/llvm/bin/amdclang
       cxx: /opt/rocm-5.1.1/llvm/bin/amdclang++

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -1,6 +1,6 @@
 compilers::
 - compiler:
-    spec: clang@13.0.0
+    spec: rocm@5.1.1
     paths:
       cc: /opt/rocm-5.1.1/llvm/bin/amdclang
       cxx: /opt/rocm-5.1.1/llvm/bin/amdclang++
@@ -13,7 +13,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@14.0.0
+    spec: rocmcc@5.2.3
     paths:
       cc: /opt/rocm-5.2.3/llvm/bin/amdclang
       cxx: /opt/rocm-5.2.3/llvm/bin/amdclang++
@@ -26,7 +26,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@15.0.0
+    spec: rocmcc@5.4.1
     paths:
       cc: /opt/rocm-5.4.1/llvm/bin/amdclang
       cxx: /opt/rocm-5.4.1/llvm/bin/amdclang++

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -25,13 +25,9 @@ packages::
     - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
   hip:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
-    - spec: hip@4.3.1
-      prefix: /opt/rocm-4.3.1/hip
-    - spec: hip@4.5.2
-      prefix: /opt/rocm-4.5.2/hip
     - spec: hip@5.0.2
       prefix: /opt/rocm-5.0.2/hip
     - spec: hip@5.1.1
@@ -41,13 +37,9 @@ packages::
     - spec: hip@5.4.1
       prefix: /opt/rocm-5.4.1/hip
   llvm-amdgpu:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@4.3.1
-      prefix: /opt/rocm-4.3.1/llvm
-    - spec: llvm-amdgpu@4.5.2
-      prefix: /opt/rocm-4.5.2/llvm
     - spec: llvm-amdgpu@5.0.2
       prefix: /opt/rocm-5.0.2/llvm
     - spec: llvm-amdgpu@5.1.1
@@ -57,13 +49,9 @@ packages::
     - spec: llvm-amdgpu@5.4.1
       prefix: /opt/rocm-5.4.1/llvm
   hsa-rocr-dev:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@4.3.1
-      prefix: /opt/rocm-4.3.1/
-    - spec: hsa-rocr-dev@4.5.2
-      prefix: /opt/rocm-4.5.2/
     - spec: hsa-rocr-dev@5.0.2
       prefix: /opt/rocm-5.0.2/
     - spec: hsa-rocr-dev@5.1.1
@@ -73,13 +61,9 @@ packages::
     - spec: hsa-rocr-dev@5.4.1
       prefix: /opt/rocm-5.4.1/
   rocminfo:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
-    - spec: rocminfo@4.3.1
-      prefix: /opt/rocm-4.3.1/
-    - spec: rocminfo@4.5.2
-      prefix: /opt/rocm-4.5.2/
     - spec: rocminfo@5.0.2
       prefix: /opt/rocm-5.0.2/
     - spec: rocminfo@5.1.1
@@ -89,13 +73,9 @@ packages::
     - spec: rocminfo@5.4.1
       prefix: /opt/rocm-5.4.1/
   rocm-device-libs:
-    version: [4.3.1, 4.5.2, 5.0.2, 5.1.1, 5.2.3, 5.4.1]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.1]
     buildable: false
     externals:
-    - spec: rocm-device-libs@4.3.1
-      prefix: /opt/rocm-4.3.1/
-    - spec: rocm-device-libs@4.5.2
-      prefix: /opt/rocm-4.5.2/
     - spec: rocm-device-libs@5.0.2
       prefix: /opt/rocm-5.0.2/
     - spec: rocm-device-libs@5.1.1

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -116,3 +116,16 @@ compilers::
     modules: []
     environment: {}
     extra_rpaths: []
+- compiler:
+    spec: clang@15.0.0
+    paths:
+      cc: /opt/rocm-5.4.1/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.1/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.1/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.1/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -104,7 +104,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@13.0.0
+    spec: rocmcc@5.3.0
     paths:
       cc: /opt/rocm-5.3.0/llvm/bin/amdclang
       cxx: /opt/rocm-5.3.0/llvm/bin/amdclang++
@@ -117,12 +117,25 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: clang@15.0.0
+    spec: rocmcc@5.4.1
     paths:
       cc: /opt/rocm-5.4.1/llvm/bin/amdclang
       cxx: /opt/rocm-5.4.1/llvm/bin/amdclang++
       f77: /opt/rocm-5.4.1/llvm/bin/amdflang
       fc: /opt/rocm-5.4.1/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: rocmcc@5.4.3
+    paths:
+      cc: /opt/rocm-5.4.3/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.3/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.3/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.3/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -27,65 +27,65 @@ packages::
     - spec: cuda@11.4.120
       prefix: /opt/toss/cudatoolkit/11.4/ 
   hip:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3]
     buildable: false
     externals:
-    - spec: hip@4.5.2
-      prefix: /opt/rocm-4.5.2/hip
-    - spec: hip@5.0.2
-      prefix: /opt/rocm-5.0.2/hip
     - spec: hip@5.2.3
       prefix: /opt/rocm-5.2.3/hip
     - spec: hip@5.3.0
       prefix: /opt/rocm-5.3.0/hip
+    - spec: hip@5.4.1
+      prefix: /opt/rocm-5.4.1/hip
+    - spec: hip@5.4.3
+      prefix: /opt/rocm-5.4.3/hip
   llvm-amdgpu:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@4.5.2
-      prefix: /opt/rocm-4.5.2/llvm
-    - spec: llvm-amdgpu@5.0.2
-      prefix: /opt/rocm-5.0.2/llvm
     - spec: llvm-amdgpu@5.2.3
       prefix: /opt/rocm-5.2.3/llvm
     - spec: llvm-amdgpu@5.3.0
       prefix: /opt/rocm-5.3.0/llvm
+    - spec: llvm-amdgpu@5.4.1
+      prefix: /opt/rocm-5.4.1/llvm
+    - spec: llvm-amdgpu@5.4.3
+      prefix: /opt/rocm-5.4.3/llvm
   hsa-rocr-dev:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@4.5.2
-      prefix: /opt/rocm-4.5.2/
-    - spec: hsa-rocr-dev@5.0.2
-      prefix: /opt/rocm-5.0.2/
     - spec: hsa-rocr-dev@5.2.3
       prefix: /opt/rocm-5.2.3/
     - spec: hsa-rocr-dev@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: hsa-rocr-dev@5.4.1
+      prefix: /opt/rocm-5.4.1/
+    - spec: hsa-rocr-dev@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocminfo:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3]
     buildable: false
     externals:
-    - spec: rocminfo@4.5.2
-      prefix: /opt/rocm-4.5.2/
-    - spec: rocminfo@5.0.2
-      prefix: /opt/rocm-5.0.2/
     - spec: rocminfo@5.2.3
       prefix: /opt/rocm-5.2.3/
     - spec: rocminfo@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: rocminfo@5.4.1
+      prefix: /opt/rocm-5.4.1/
+    - spec: rocminfo@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocm-device-libs:
-    version: [4.5.2, 5.0.2, 5.2.3, 5.3.0]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3]
     buildable: false
     externals:
-    - spec: rocm-device-libs@4.5.2
-      prefix: /opt/rocm-4.5.2/
-    - spec: rocm-device-libs@5.0.2
-      prefix: /opt/rocm-5.0.2/
     - spec: rocm-device-libs@5.2.3
       prefix: /opt/rocm-5.2.3/
     - spec: rocm-device-libs@5.3.0
       prefix: /opt/rocm-5.3.0/
+    - spec: rocm-device-libs@5.4.1
+      prefix: /opt/rocm-5.4.1/
+    - spec: rocm-device-libs@5.4.3
+      prefix: /opt/rocm-5.4.3/
   rocprim:
     version: [5.2.3, 5.3.0]
     buildable: false


### PR DESCRIPTION
This PR should do 5 things:

- Fix my conflict rule in Umpire's package.py file to actually detect the version of rocm
- **Add** rocm updated versions 5.4.1 and 5.4.3 for tioga
- **Add** the clang@15 compiler associated with rocm 4.5.1 for tioga -----> _**Will this version also work for 5.4.3?**_
- **remove** older rocm versions < 5.0 for tioga
- **Remove** older rocm versions < 5.0 for corona