### PR TITLE
Enable use as a spack repo

### DIFF
--- a/packages/chai/package.py
+++ b/packages/chai/package.py
@@ -8,10 +8,9 @@ import socket
 import re
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
-
+from spack.pkg.llnl.radiuss.camp import hip_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import cuda_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import blt_link_helpers
 
 
 class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -9,9 +9,9 @@ import glob
 import re
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from spack.pkg.llnl.radiuss.camp import hip_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import cuda_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import blt_link_helpers
 
 
 class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -10,9 +10,9 @@ import re
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from spack.pkg.llnl.radiuss.camp import hip_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import cuda_for_radiuss_projects
+from spack.pkg.llnl.radiuss.camp import blt_link_helpers
 
 
 

--- a/repo.yaml
+++ b/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'llnl.radiuss'


### PR DESCRIPTION
In order to enable this code repo as a spack repo I added a repo.yaml.

I also had to change the expected namespace of the 'camp' package that is being imported into the other packages.  Note: This will break usage if people are manually copying these into a spack installation, so I'm putting this PR up as a point of discussion to look at.

I'm guessing that long term plans are to merge some of these package updates to the spack main repo and not have these importing cross importing packages defined in the camp package?  The hip_for_radiuss_project and cuda_for_radiuss_project code looks like functionality that Spack should fold into their RocmPackage and CudaPackage, for example.