### PR TITLE
Intel oneapi requires a extra directory to use gcc

### DIFF
--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -425,9 +425,9 @@ compilers::
       f77: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
       fc: /usr/tce/packages/intel/intel-oneapi.2022.2/bin/ifx
     flags:
-      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
     operating_system: rhel7
     target: x86_64
     modules: []


### PR DESCRIPTION
Nothing works without the `rh` at the end of the `--gcc-toolchain` command line argument.

Before:

```
$ /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -std=c++17 std_align.cpp 
std_align.cpp:1:10: fatal error: 'iostream' file not found
#include <iostream>
         ^~~~~~~~~~
1 error generated.
```

After:
```
$ /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh -std=c++17 std_align.cpp 

```
