### PR TITLE
[Woptim] latest 2023.03 changes

### DIFF
--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -75,9 +75,3 @@ packages:
     externals:
     - spec: python@3.8.2
       prefix: /usr/tce/packages/python/python-3.8.2
-  elfutils:
-    buildable: false
-    version: [0.175]
-    externals:
-    - spec: elfutils@0.175
-      prefix: /usr/tce/packages/elfutils/elfutils-0.175

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -61,7 +61,7 @@ def hip_for_radiuss_projects(options, spec, spec_compiler):
     if "%gcc" in spec or spec_uses_toolchain(spec):
         if "%gcc" in spec:
             gcc_bin = os.path.dirname(spec_compiler.cxx)
-            gcc_prefix = join_path(gcc_bin, "..")
+            gcc_prefix = os.path.join(gcc_bin, "..")
         else:
             gcc_prefix = spec_uses_toolchain(spec)[0]
         options.append(cmake_cache_string("HIP_CLANG_FLAGS", "--gcc-toolchain={0}".format(gcc_prefix)))
@@ -111,7 +111,7 @@ def blt_link_helpers(options, spec, spec_compiler):
         _existing_paths = []
         for root in _roots:
             for subdir in _subdirs:
-                _curr_path = pjoin(root, subdir)
+                _curr_path = os.path.join(root, subdir)
                 if os.path.exists(_curr_path):
                     _existing_paths.append(_curr_path)
         if _existing_paths:

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -114,6 +114,16 @@ def blt_link_helpers(options, spec, spec_compiler):
             options.append(cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
+    if "cce" in self_compiler.cxx:
+        #AXOM STYLE
+        #libdir = pjoin(os.path.dirname(os.path.dirname(self.compiler.fc)), "lib")
+        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(self_compiler.version)
+        description = (
+            "Adds a missing rpath for libraries " "associated with the fortran compiler"
+        )
+        linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
+        options.append(cmake_cache_string("BLT_EXE_LINKER_FLAGS", linker_flags, description))
+
 
 class Camp(CMakePackage, CudaPackage, ROCmPackage):
     """

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -123,12 +123,8 @@ def blt_link_helpers(options, spec, spec_compiler):
             )
 
     if "cce" in spec_compiler.cxx:
-        #AXOM STYLE
-        #libdir = pjoin(os.path.dirname(os.path.dirname(self.compiler.fc)), "lib")
-        #David’s suggestion (works)
+        # Here is where to find libs that work for fortran
         libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
-        #Another attempt
-        libdir = "/usr/tce/packages/cce-tce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         description = (
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -114,10 +114,10 @@ def blt_link_helpers(options, spec, spec_compiler):
             options.append(cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
-    if "cce" in self_compiler.cxx:
+    if "cce" in spec_compiler.cxx:
         #AXOM STYLE
         #libdir = pjoin(os.path.dirname(os.path.dirname(self.compiler.fc)), "lib")
-        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(self_compiler.version)
+        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         description = (
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -125,7 +125,10 @@ def blt_link_helpers(options, spec, spec_compiler):
     if "cce" in spec_compiler.cxx:
         #AXOM STYLE
         #libdir = pjoin(os.path.dirname(os.path.dirname(self.compiler.fc)), "lib")
+        #David’s suggestion (works)
         libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
+        #Another attempt
+        libdir = "/usr/tce/packages/cce-tce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         description = (
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -60,7 +60,6 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     variant("openmp", default=True, description="Build OpenMP backend")
     variant("shared", default=True, description="Build shared libs")
-    variant("libcpp", default=False, description="Uses libc++ instead of libstdc++")
     variant("desul", default=False, description="Build desul atomics backend")
     variant("vectorization", default=True, description="Build SIMD/SIMT intrinsics support")
 
@@ -121,7 +120,6 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         return sys_type
 
     @property
-    # TODO: name cache file conditionally to cuda and libcpp variants
     def cache_name(self):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:
@@ -148,7 +146,6 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
         #### BEGIN: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
-        # Goal: add +libcpp specific flags
         flags = spec.compiler_flags
 
         # use global spack compiler flags
@@ -158,14 +155,10 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
             cppflags += " "
 
         cflags = cppflags + " ".join(flags["cflags"])
-        if "+libcpp" in spec:
-            cflags += " ".join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
         if cflags:
             entries.append(cmake_cache_string("CMAKE_C_FLAGS", cflags))
 
         cxxflags = cppflags + " ".join(flags["cxxflags"])
-        if "+libcpp" in spec:
-            cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
         if cxxflags:
             entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
 

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -105,6 +105,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.14:", when="@2022.03.0:", type="build")
     depends_on("cmake@:3.20", when="@2022.03.0:2022.03 +rocm", type="build")
 
+    depends_on("blt@develop", type="build", when="@develop")
     depends_on("blt@0.5.2:", type="build", when="@2022.10.0:")
     depends_on("blt@0.5.0:", type="build", when="@2022.03.0:")
     depends_on("blt@0.4.1", type="build", when="@6.0.0")

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -89,7 +89,6 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         multi=False,
         description="Tests to run",
     )
-    variant("libcpp", default=False, description="Uses libc++ instead of libstdc++")
     variant("tools", default=False, description="Enable tools")
     variant("backtrace", default=False, description="Enable backtrace tools")
     variant("dev_benchmarks", default=False, description="Enable Developer Benchmarks")
@@ -174,7 +173,6 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         return sys_type
 
     @property
-    # TODO: name cache file conditionally to cuda and libcpp variants
     def cache_name(self):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:
@@ -213,7 +211,6 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("{}ENABLE_C".format(option_prefix), "+c" in spec))
 
         #### BEGIN: Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
-        # Goal: add +libcpp specific flags
         flags = spec.compiler_flags
 
         # use global spack compiler flags
@@ -223,14 +220,10 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
             cppflags += " "
 
         cflags = cppflags + " ".join(flags["cflags"])
-        if "+libcpp" in spec:
-            cflags += " ".join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
         if cflags:
             entries.append(cmake_cache_string("CMAKE_C_FLAGS", cflags))
 
         cxxflags = cppflags + " ".join(flags["cxxflags"])
-        if "+libcpp" in spec:
-            cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
         if cxxflags:
             entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
 

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -93,7 +93,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("tools", default=False, description="Enable tools")
     variant("backtrace", default=False, description="Enable backtrace tools")
     variant("dev_benchmarks", default=False, description="Enable Developer Benchmarks")
-    variant("device_alloc", default=True, description="Enable DeviceAllocator")
+    variant("device_alloc", default=False, description="Enable DeviceAllocator")
     variant("werror", default=True, description="Enable warnings as errors")
     variant("asan", default=False, description="Enable ASAN")
     variant("sanitizer_tests", default=False, description="Enable address sanitizer tests")

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -434,35 +434,6 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: oneapi@2022.3
-    paths:
-      cc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icx
-      cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
-      f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-      fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-    flags: {}
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: oneapi@2022.3.gcc.8.3.1
-    paths:
-      cc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icx
-      cxx: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/icpx
-      f77: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-      fc: /usr/tce/packages/intel/intel-oneapi.2022.3/bin/ifx
-    flags:
-      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
-    operating_system: rhel7
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: pgi@17.10
     paths:
       cc: /usr/tce/packages/pgi/pgi-17.10/bin/pgcc

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -428,7 +428,7 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
-      fflags: --gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -458,7 +458,7 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
-      fflags: --gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []

--- a/toss_3_x86_64_ib/compilers.yaml
+++ b/toss_3_x86_64_ib/compilers.yaml
@@ -428,7 +428,7 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
+      fflags: --gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []
@@ -458,7 +458,7 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
-      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1/rh
+      fflags: --gcc-name=/usr/tce/packages/gcc/gcc-8.3.1/rh/bin/gcc
     operating_system: rhel7
     target: x86_64
     modules: []


### PR DESCRIPTION
Those are my latest changes for Umpire & Co.

- Suggested management of intel oneapi versionning: set the "global" version as the one Spack would find, not the one the path suggests.

- Add necessary lib directory to cce compiler to build fortran code correctly.

- Improve syntax using Axom package as reference.