### PR TITLE
Add RAJA 2022.10.5 tag.

### DIFF
--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -25,6 +25,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop", submodules=False)
     version("main", branch="main", submodules=False)
+    version("2022.10.5", tag="v2022.10.5", submodules=False)
     version("2022.10.4", tag="v2022.10.4", submodules=False)
     version("2022.10.3", tag="v2022.10.3", submodules=False)
     version("2022.10.2", tag="v2022.10.2", submodules=False)


### PR DESCRIPTION
Some projects need the latest RAJA tag.