### PR TITLE
New new compiler specs

### DIFF
--- a/blueos_3_ppc64le_ib/compilers.yaml
+++ b/blueos_3_ppc64le_ib/compilers.yaml
@@ -246,6 +246,21 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: clang@13.0.1.ibm.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-13.0.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-13.0.1/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@14.0.5.ibm
     paths:
       cc: /usr/tce/packages/clang/clang-ibm-14.0.5/bin/clang
@@ -282,6 +297,22 @@ compilers:
       fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
       f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
     flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@15.0.6.ibm.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-15.0.6/bin/clang++
+      fc: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2021.09.22/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     operating_system: rhel7
     target: ppc64le
     modules: []
@@ -434,6 +465,35 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: xl@16.1.1.14
+    paths:
+      cc: /usr/tce/packages/xl/xl-2023.03.13/bin/xlc_r
+      cxx: /usr/tce/packages/xl/xl-2023.03.13/bin/xlC_r
+      fc: /usr/tce/packages/xl/xl-2023.03.13/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2023.03.13/bin/xlf_r
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: xl@16.1.1.14.gcc.8.3.1
+    paths:
+      cc: /usr/tce/packages/xl/xl-2023.03.13/bin/xlc_r
+      cxx: /usr/tce/packages/xl/xl-2023.03.13/bin/xlC_r
+      fc: /usr/tce/packages/xl/xl-2023.03.13/bin/xlf2003_r
+      f77: /usr/tce/packages/xl/xl-2023.03.13/bin/xlf_r
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@default
     paths:
       cc: pgcc
@@ -486,12 +546,38 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: pgi@22.7
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-22.7/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-22.7/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-22.7/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-22.7/bin/pgf90
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@22.11
     paths:
       cc: /usr/tce/packages/pgi/pgi-22.11/bin/pgcc
       cxx: /usr/tce/packages/pgi/pgi-22.11/bin/pgc++
       f77: /usr/tce/packages/pgi/pgi-22.11/bin/pgfortran
       fc: /usr/tce/packages/pgi/pgi-22.11/bin/pgf90
+    flags: {}
+    operating_system: rhel7
+    target: ppc64le
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@23.1
+    paths:
+      cc: /usr/tce/packages/pgi/pgi-23.1/bin/pgcc
+      cxx: /usr/tce/packages/pgi/pgi-23.1/bin/pgc++
+      f77: /usr/tce/packages/pgi/pgi-23.1/bin/pgfortran
+      fc: /usr/tce/packages/pgi/pgi-23.1/bin/pgf90
     flags: {}
     operating_system: rhel7
     target: ppc64le

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -52,12 +52,12 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: pgi@20.4
+    spec: rocmcc@5.4.3
     paths:
-      cc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgcc
-      cxx: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgc++
-      f77: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgfortran
-      fc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgfortran
+      cc: /opt/rocm-5.4.3/llvm/bin/amdclang
+      cxx: /opt/rocm-5.4.3/llvm/bin/amdclang++
+      f77: /opt/rocm-5.4.3/llvm/bin/amdflang
+      fc: /opt/rocm-5.4.3/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64
@@ -65,12 +65,25 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.5.0
+    spec: rocmcc@5.5.0
     paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
+      cc: /opt/rocm-5.5.0/llvm/bin/amdclang
+      cxx: /opt/rocm-5.5.0/llvm/bin/amdclang++
+      f77: /opt/rocm-5.5.0/llvm/bin/amdflang
+      fc: /opt/rocm-5.5.0/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: pgi@20.4
+    paths:
+      cc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgcc
+      cxx: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgc++
+      f77: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgfortran
+      fc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgfortran
     flags: {}
     operating_system: rhel8
     target: x86_64
@@ -149,12 +162,51 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@8.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: gcc@10.3.1
     paths:
       cc: /usr/tce/packages/gcc/gcc-10.3.1/bin/gcc
       cxx: /usr/tce/packages/gcc/gcc-10.3.1/bin/g++
       f77: /usr/tce/packages/gcc/gcc-10.3.1/bin/gfortran
       fc: /usr/tce/packages/gcc/gcc-10.3.1/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@11.2.1
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-11.2.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-11.2.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-11.2.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-11.2.1/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@12.1.1
+    paths:
+      cc: /usr/tce/packages/gcc/gcc-12.1.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-12.1.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-12.1.1/bin/gfortran
+      fc: /usr/tce/packages/gcc/gcc-12.1.1/bin/gfortran
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -104,6 +104,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: gcc@12.1.1
+    paths:
+      cc: /opt/cray/pe/gcc/12.1.1/bin/gcc
+      cxx: /opt/cray/pe/gcc/12.1.1/bin/g++
+      f77: /opt/cray/pe/gcc/12.1.1/bin/gfortran
+      fc: /opt/cray/pe/gcc/12.1.1/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: rocmcc@5.2.3
     paths:
       cc: /opt/rocm-5.2.3/llvm/bin/amdclang
@@ -149,6 +162,19 @@ compilers::
       cxx: /opt/rocm-5.4.3/llvm/bin/amdclang++
       f77: /opt/rocm-5.4.3/llvm/bin/amdflang
       fc: /opt/rocm-5.4.3/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: rocmcc@5.5.0
+    paths:
+      cc: /opt/rocm-5.5.0/llvm/bin/amdclang
+      cxx: /opt/rocm-5.5.0/llvm/bin/amdclang++
+      f77: /opt/rocm-5.5.0/llvm/bin/amdflang
+      fc: /opt/rocm-5.5.0/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64


### PR DESCRIPTION
Adds newer compiler specs and adds some that are system defaults.

NOTES: 
- toss_4 specs for cray system has a strange mixture of locations of GNU compilers. Not sure which is best or if they all work.
- toss_4 (non-cray) specs contain a duplicate gcc@10.3.1 spec -- spec name is the same, but compilers are different. Unless there is a reason to do it, I think we should stay away from the "magic" compilers for now.