### PR TITLE
Replacing explicit module import with relative module import

### DIFF
--- a/packages/caliper/package.py
+++ b/packages/caliper/package.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
+from .camp import hip_for_radiuss_projects
 
 
 class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/packages/chai/package.py
+++ b/packages/chai/package.py
@@ -8,9 +8,9 @@ import socket
 import re
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from .camp import hip_for_radiuss_projects
+from .camp import cuda_for_radiuss_projects
+from .camp import blt_link_helpers
 
 
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -9,9 +9,9 @@ import glob
 import re
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from .camp import hip_for_radiuss_projects
+from .camp import cuda_for_radiuss_projects
+from .camp import blt_link_helpers
 
 
 class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -11,9 +11,9 @@ from os import environ as env
 from os.path import join as pjoin
 
 from spack import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from .camp import hip_for_radiuss_projects
+from .camp import cuda_for_radiuss_projects
+from .camp import blt_link_helpers
 
 
 class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):

--- a/packages/umpire/package.py
+++ b/packages/umpire/package.py
@@ -10,9 +10,9 @@ import re
 import llnl.util.tty as tty
 
 from spack.package import *
-from spack.pkg.builtin.camp import hip_for_radiuss_projects
-from spack.pkg.builtin.camp import cuda_for_radiuss_projects
-from spack.pkg.builtin.camp import blt_link_helpers
+from .camp import hip_for_radiuss_projects
+from .camp import cuda_for_radiuss_projects
+from .camp import blt_link_helpers
 
 
 

--- a/repo.yaml
+++ b/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'llnl.radiuss'


### PR DESCRIPTION
This is needed if someone wants to spike your packages and provide local modifications to the radiuss packages. The explicit paths to camp make it hard to use these without replacing the packages in a top-level spack directory.