### PR TITLE
Add CMAKE_HIP_ARCHITECTURES flag to camp

### DIFF
--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -185,6 +185,7 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
             hip_repair_options(options, spec)
 
             archs = self.spec.variants["amdgpu_target"].value
+            options.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(archs))
             if archs != "none":
                 arch_str = ",".join(archs)
                 options.append("-DHIP_HIPCC_FLAGS=--amdgpu-target={0}".format(arch_str))


### PR DESCRIPTION
This PR:
- Adds the `CMAKE_HIP_ARCHITECTURES` flag to camp's CMake configure line.

This was causing an issue in axom where the exported `blt::blt_hip` target by camp was adding a `--offload-arch=gfx900` flag during linking on toss 4 cray systems, causing a failure when compiling with cce@15.0.1

Background on how the wrong `--offload-arch` was being added:

By default, blt sets CMAKE_HIP_ARCHITECTURES to gfx900, with the expectation that the user will overwrite it with the right architecture during configuration or in their host-config:
https://github.com/LLNL/blt/blob/4e1fa86639496e30a22cc10eaf0cd199bcc53008/cmake/BLTOptions.cmake#L64
https://github.com/LLNL/blt/blob/4e1fa86639496e30a22cc10eaf0cd199bcc53008/host-configs/llnl/toss_4_x86_64_ib_cray/clang%4014.0.0_hip.cmake#L55

CMAKE_HIP_ARCHITECTURES is used to remove flags for architectures that were not explicitly specified:
https://github.com/LLNL/blt/blob/4e1fa86639496e30a22cc10eaf0cd199bcc53008/cmake/thirdparty/SetupHIP.cmake#L54-L55

For spack packages like umpire, axom, raja, etc. CMAKE_HIP_ARCHITECTURES is defined by being a CachedCMakePackage:
https://github.com/spack/spack/blob/c2bafd7b7fc74d5672beaf79fd808c62900151f6/lib/spack/spack/build_systems/cached_cmake.py#L261C7-L278 

The camp package is not currently a CachedCMakePackage, and needs to explicitly set the CMAKE_HIP_ARCHITECTURES flag.

An alternative way to fix the issue is to make camp a CachedCMakePackage, but that requires further testing.