### PR TITLE
Task/specs update

### DIFF
--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -127,7 +127,7 @@ def blt_link_helpers(options, spec, compiler):
         if version == "16.0.0":
             # Here is another directory added by cce@16.0.0
             libdir = os.path.join(libdir,"x86_64-unknown-linux-gnu")
-            linker_flags.append(" -Wl,-rpath,{0}".format(libdir))
+            linker_flags += " -Wl,-rpath,{0}".format(libdir)
 
         options.append(cmake_cache_string("BLT_EXE_LINKER_FLAGS", linker_flags, description))
 

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -93,7 +93,7 @@ def blt_link_helpers(options, spec, compiler):
         if any(f_comp in compiler.fc for f_comp in fortran_compilers) and ("clang" in compiler.cxx):
             # Pass fortran compiler lib as rpath to find missing libstdc++
             libdir = os.path.join(os.path.dirname(
-                           os.path.dirname(f_comp)), "lib")
+                           os.path.dirname(compiler.fc)), "lib")
             flags = ""
             for _libpath in [libdir, libdir + "64"]:
                 if os.path.exists(_libpath):

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -36,7 +36,7 @@ def hip_repair_cache(options, spec):
         )
     )
 
-def hip_for_radiuss_projects(options, spec, spec_compiler):
+def hip_for_radiuss_projects(options, spec, compiler):
     # Here is what is typically needed for radiuss projects when building with rocm
     hip_root = spec["hip"].prefix
     rocm_root = hip_root + "/.."
@@ -60,7 +60,7 @@ def hip_for_radiuss_projects(options, spec, spec_compiler):
     hip_link_flags = ""
     if "%gcc" in spec or spec_uses_toolchain(spec):
         if "%gcc" in spec:
-            gcc_bin = os.path.dirname(spec_compiler.cxx)
+            gcc_bin = os.path.dirname(compiler.cxx)
             gcc_prefix = os.path.join(gcc_bin, "..")
         else:
             gcc_prefix = spec_uses_toolchain(spec)[0]
@@ -86,14 +86,14 @@ def cuda_for_radiuss_projects(options, spec):
         cuda_flags.append("-Xcompiler -mno-float128")
     options.append(cmake_cache_string("CMAKE_CUDA_FLAGS", " ".join(cuda_flags)))
 
-def blt_link_helpers(options, spec, spec_compiler):
+def blt_link_helpers(options, spec, compiler):
     ### From local package:
-    if spec_compiler.fc:
+    if compiler.fc:
         fortran_compilers = ["gfortran", "xlf"]
-        if any(compiler in spec_compiler.fc for compiler in fortran_compilers) and ("clang" in spec_compiler.cxx):
+        if any(compiler in compiler.fc for compiler in fortran_compilers) and ("clang" in compiler.cxx):
             # Pass fortran compiler lib as rpath to find missing libstdc++
             libdir = os.path.join(os.path.dirname(
-                           os.path.dirname(spec_compiler.fc)), "lib")
+                           os.path.dirname(compiler.fc)), "lib")
             flags = ""
             for _libpath in [libdir, libdir + "64"]:
                 if os.path.exists(_libpath):
@@ -107,22 +107,22 @@ def blt_link_helpers(options, spec, spec_compiler):
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
     compilers_using_toolchain = ["pgc++", "xlc++", "xlC_r", "icpc", "clang++", "icpx"]
-    if any(compiler in spec_compiler.cxx for compiler in compilers_using_toolchain):
+    if any(compiler in compiler.cxx for compiler in compilers_using_toolchain):
         if spec_uses_toolchain(spec) or spec_uses_gccname(spec):
 
             # Ignore conflicting default gcc toolchain
             options.append(cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
-    if "cce" in spec_compiler.cxx:
+    if "cce" in compiler.cxx:
         description = (
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )
         # Here is where to find libs that work for fortran
-        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,{0}".format(libdir)
+        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(compiler.version)
 
-        version = "{0}".format(spec_compiler.version)
+        version = "{0}".format(compiler.version)
 
         if version == "16.0.0":
             # Here is another directory added by cce@16.0.0

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -115,12 +115,18 @@ def blt_link_helpers(options, spec, spec_compiler):
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
     if "cce" in spec_compiler.cxx:
-        # Here is where to find libs that work for fortran
-        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         description = (
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )
+        # Here is where to find libs that work for fortran
+        libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
         linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
+
+        if spec_compiler.version == "16.0.0":
+            # Here is another directory added by cce@16.0.0
+            libdir = os.path.join(libdir,"x86_64-unknown-linux-gnu")
+            linker_flags += " -Wl,-rpath," + libdir
+
         options.append(cmake_cache_string("BLT_EXE_LINKER_FLAGS", linker_flags, description))
 
 

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -137,6 +137,7 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ["trws"]
 
     version("main", branch="main", submodules="False")
+    version("2023.06.0", tag="v2023.06.0", submodules=False)
     version("2022.10.1", sha256="2d12f1a46f5a6d01880fc075cfbd332e2cf296816a7c1aa12d4ee5644d386f02")
     version("2022.10.0", sha256="3561c3ef00bbcb61fe3183c53d49b110e54910f47e7fc689ad9ccce57e55d6b8")
     version("2022.03.2", sha256="bc4aaeacfe8f2912e28f7a36fc731ab9e481bee15f2c6daf0cb208eed3f201eb")

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -90,10 +90,10 @@ def blt_link_helpers(options, spec, compiler):
     ### From local package:
     if compiler.fc:
         fortran_compilers = ["gfortran", "xlf"]
-        if any(compiler in compiler.fc for compiler in fortran_compilers) and ("clang" in compiler.cxx):
+        if any(fortran in compiler.fc for fortran in fortran_compilers) and ("clang" in compiler.cxx):
             # Pass fortran compiler lib as rpath to find missing libstdc++
             libdir = os.path.join(os.path.dirname(
-                           os.path.dirname(compiler.fc)), "lib")
+                           os.path.dirname(fortran)), "lib")
             flags = ""
             for _libpath in [libdir, libdir + "64"]:
                 if os.path.exists(_libpath):

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -90,10 +90,10 @@ def blt_link_helpers(options, spec, compiler):
     ### From local package:
     if compiler.fc:
         fortran_compilers = ["gfortran", "xlf"]
-        if any(fortran in compiler.fc for fortran in fortran_compilers) and ("clang" in compiler.cxx):
+        if any(f_comp in compiler.fc for f_comp in fortran_compilers) and ("clang" in compiler.cxx):
             # Pass fortran compiler lib as rpath to find missing libstdc++
             libdir = os.path.join(os.path.dirname(
-                           os.path.dirname(fortran)), "lib")
+                           os.path.dirname(f_comp)), "lib")
             flags = ""
             for _libpath in [libdir, libdir + "64"]:
                 if os.path.exists(_libpath):
@@ -107,7 +107,7 @@ def blt_link_helpers(options, spec, compiler):
             "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
 
     compilers_using_toolchain = ["pgc++", "xlc++", "xlC_r", "icpc", "clang++", "icpx"]
-    if any(compiler in compiler.cxx for compiler in compilers_using_toolchain):
+    if any(tc_comp in compiler.cxx for tc_comp in compilers_using_toolchain):
         if spec_uses_toolchain(spec) or spec_uses_gccname(spec):
 
             # Ignore conflicting default gcc toolchain

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -120,12 +120,14 @@ def blt_link_helpers(options, spec, spec_compiler):
         )
         # Here is where to find libs that work for fortran
         libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(spec_compiler.version)
-        linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
+        linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,{0}".format(libdir)
 
-        if spec_compiler.version == "16.0.0":
+        version = "{0}".format(spec_compiler.version)
+
+        if version == "16.0.0":
             # Here is another directory added by cce@16.0.0
             libdir = os.path.join(libdir,"x86_64-unknown-linux-gnu")
-            linker_flags += " -Wl,-rpath," + libdir
+            linker_flags += " -Wl,-rpath,{0}".format(libdir)
 
         options.append(cmake_cache_string("BLT_EXE_LINKER_FLAGS", linker_flags, description))
 

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -119,15 +119,15 @@ def blt_link_helpers(options, spec, compiler):
             "Adds a missing rpath for libraries " "associated with the fortran compiler"
         )
         # Here is where to find libs that work for fortran
-        linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,{0}".format(libdir)
         libdir = "/opt/cray/pe/cce/{0}/cce-clang/x86_64/lib".format(compiler.version)
+        linker_flags = "${{BLT_EXE_LINKER_FLAGS}} -Wl,-rpath,{0}".format(libdir)
 
         version = "{0}".format(compiler.version)
 
         if version == "16.0.0":
             # Here is another directory added by cce@16.0.0
             libdir = os.path.join(libdir,"x86_64-unknown-linux-gnu")
-            linker_flags += " -Wl,-rpath,{0}".format(libdir)
+            linker_flags.append(" -Wl,-rpath,{0}".format(libdir))
 
         options.append(cmake_cache_string("BLT_EXE_LINKER_FLAGS", linker_flags, description))
 

--- a/packages/raja/package.py
+++ b/packages/raja/package.py
@@ -197,8 +197,9 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         entries.append(cmake_cache_option("RAJA_ENABLE_OPENMP_TASK", "+omptask" in spec))
 
+        entries.append(cmake_cache_string("BLT_CXX_STD","c++14"))
+
         if "+desul" in spec:
-            entries.append(cmake_cache_string("BLT_CXX_STD","c++14"))
             if "+cuda" in spec:
                 entries.append(cmake_cache_string("CMAKE_CUDA_STANDARD", "14"))
 

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -139,7 +139,7 @@ compilers::
       cc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icx
       cxx: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icpx
       f77: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx
-      fc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icx
+      fc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx
     flags: {}
     operating_system: rhel8
     target: x86_64
@@ -152,7 +152,7 @@ compilers::
       cc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icx
       cxx: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icpx
       f77: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx
-      fc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icx
+      fc: /usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -78,19 +78,6 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@10.3.1
-    paths:
-      cc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gcc
-      cxx: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/g++
-      f77: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
-      fc: /usr/tce/packages/gcc-tce/gcc-10.3.1/bin/gfortran
-    flags: {}
-    operating_system: rhel8
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: intel@19.1.2
     paths:
       cc: /usr/tce/packages/intel-classic/intel-classic-19.1.2/bin/icc

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -125,9 +125,9 @@ compilers::
       f77: /usr/tce/packages/intel-classic/intel-classic-19.1.2/bin/ifort
       fc: /usr/tce/packages/intel-classic/intel-classic-19.1.2/bin/ifort
     flags:
-      cflags: -gcc-name=/usr/bin/gcc
-      cxxflags: -gcc-name=/usr/bin/g++
-      fflags: -gcc-name=/usr/bin/gcc
+      cflags: -gcc-name=/usr/tce/packages/gcc-10.3.1/bin/gcc
+      cxxflags: -gcc-name=/usr/tce/packages/gcc-10.3.1/bin/g++
+      fflags: -gcc-name=/usr/tce/packages/gcc-10.3.1/bin/gfortran
     operating_system: rhel8
     target: x86_64
     modules: []

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -65,6 +65,32 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: rocmcc@5.5.1
+    paths:
+      cc: /opt/rocm-5.5.1/llvm/bin/amdclang
+      cxx: /opt/rocm-5.5.1/llvm/bin/amdclang++
+      f77: /opt/rocm-5.5.1/llvm/bin/amdflang
+      fc: /opt/rocm-5.5.1/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: rocmcc@5.6.0
+    paths:
+      cc: /opt/rocm-5.6.0/llvm/bin/amdclang
+      cxx: /opt/rocm-5.6.0/llvm/bin/amdclang++
+      f77: /opt/rocm-5.6.0/llvm/bin/amdflang
+      fc: /opt/rocm-5.6.0/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: pgi@20.4
     paths:
       cc: /opt/toss/pgi/20.4/linux86-64-llvm/20.4/bin/pgcc

--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -118,7 +118,7 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: intel@19.1.2.gcc.8.5.0
+    spec: intel@19.1.2.gcc.10.3.1
     paths:
       cc: /usr/tce/packages/intel-classic/intel-classic-19.1.2/bin/icc
       cxx: /usr/tce/packages/intel-classic/intel-classic-19.1.2/bin/icpc
@@ -156,19 +156,6 @@ compilers::
     flags:
       cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1
       cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1
-    operating_system: rhel8
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.5.0
-    paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
-    flags: {}
     operating_system: rhel8
     target: x86_64
     modules: []

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -27,7 +27,7 @@ packages::
     - spec: cuda@10.1.168
       prefix: /usr/tce/packages/cuda/cuda-10.1.168
   hip:
-    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: hip@5.0.2
@@ -40,8 +40,12 @@ packages::
       prefix: /opt/rocm-5.4.3/hip
     - spec: hip@5.5.0
       prefix: /opt/rocm-5.5.0/hip
+    - spec: hip@5.5.1
+      prefix: /opt/rocm-5.5.1/hip
+    - spec: hip@5.6.0
+      prefix: /opt/rocm-5.6.0/hip
   llvm-amdgpu:
-    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: llvm-amdgpu@5.0.2
@@ -54,8 +58,12 @@ packages::
       prefix: /opt/rocm-5.4.3/llvm
     - spec: llvm-amdgpu@5.5.0
       prefix: /opt/rocm-5.5.0/llvm
+    - spec: llvm-amdgpu@5.5.1
+      prefix: /opt/rocm-5.5.1/llvm
+    - spec: llvm-amdgpu@5.6.0
+      prefix: /opt/rocm-5.6.0/llvm
   hsa-rocr-dev:
-    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@5.0.2
@@ -68,8 +76,12 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: hsa-rocr-dev@5.5.0
       prefix: /opt/rocm-5.5.0/
+    - spec: hsa-rocr-dev@5.5.1
+      prefix: /opt/rocm-5.5.1/
+    - spec: hsa-rocr-dev@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocminfo:
-    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocminfo@5.0.2
@@ -82,8 +94,12 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocminfo@5.5.0
       prefix: /opt/rocm-5.5.0/
+    - spec: rocminfo@5.5.1
+      prefix: /opt/rocm-5.5.1/
+    - spec: rocminfo@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocm-device-libs:
-    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.0.2, 5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocm-device-libs@5.0.2
@@ -96,8 +112,12 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocm-device-libs@5.5.0
       prefix: /opt/rocm-5.5.0/
+    - spec: rocm-device-libs@5.5.1
+      prefix: /opt/rocm-5.5.1/
+    - spec: rocm-device-libs@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocprim:
-    version: [5.1.1, 5.2.3, 5.4.3, 5.5.0]
+    version: [5.1.1, 5.2.3, 5.4.3, 5.5.0, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocprim@5.1.1
@@ -108,6 +128,10 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocprim@5.5.0
       prefix: /opt/rocm-5.5.0/
+    - spec: rocprim@5.5.1
+      prefix: /opt/rocm-5.5.1/
+    - spec: rocprim@5.6.0
+      prefix: /opt/rocm-5.6.0/
   mvapich2:
     buildable: false
     externals:

--- a/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/toss_4_x86_64_ib_cray/compilers.yaml
@@ -52,6 +52,19 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: cce@16.0.0
+    paths:
+      cc: /usr/tce/packages/cce-tce/cce-16.0.0/bin/craycc
+      cxx: /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayCC
+      f77: /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
+      fc: /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@13.0.1
     paths:
       cc: /usr/bin/clang
@@ -175,6 +188,19 @@ compilers::
       cxx: /opt/rocm-5.5.1/llvm/bin/amdclang++
       f77: /opt/rocm-5.5.1/llvm/bin/amdflang
       fc: /opt/rocm-5.5.1/llvm/bin/amdflang
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: rocmcc@5.6.0
+    paths:
+      cc: /opt/rocm-5.6.0/llvm/bin/amdclang
+      cxx: /opt/rocm-5.6.0/llvm/bin/amdclang++
+      f77: /opt/rocm-5.6.0/llvm/bin/amdflang
+      fc: /opt/rocm-5.6.0/llvm/bin/amdflang
     flags: {}
     operating_system: rhel8
     target: x86_64

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -29,7 +29,7 @@ packages::
     - spec: cuda@11.4.120
       prefix: /opt/toss/cudatoolkit/11.4/
   hip:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: hip@5.2.3
@@ -42,8 +42,10 @@ packages::
       prefix: /opt/rocm-5.4.3/hip
     - spec: hip@5.5.1
       prefix: /opt/rocm-5.5.1/hip
+    - spec: hip@5.6.0
+      prefix: /opt/rocm-5.6.0/hip
   llvm-amdgpu:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: llvm-amdgpu@5.2.3
@@ -56,8 +58,10 @@ packages::
       prefix: /opt/rocm-5.4.3/llvm
     - spec: llvm-amdgpu@5.5.1
       prefix: /opt/rocm-5.5.1/llvm
+    - spec: llvm-amdgpu@5.6.0
+      prefix: /opt/rocm-5.6.0/llvm
   hsa-rocr-dev:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: hsa-rocr-dev@5.2.3
@@ -70,8 +74,10 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: hsa-rocr-dev@5.5.1
       prefix: /opt/rocm-5.5.1/
+    - spec: hsa-rocr-dev@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocminfo:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocminfo@5.2.3
@@ -84,8 +90,10 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocminfo@5.5.1
       prefix: /opt/rocm-5.5.1/
+    - spec: rocminfo@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocm-device-libs:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocm-device-libs@5.2.3
@@ -98,8 +106,10 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocm-device-libs@5.5.1
       prefix: /opt/rocm-5.5.1/
+    - spec: rocm-device-libs@5.6.0
+      prefix: /opt/rocm-5.6.0/
   rocprim:
-    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1]
+    version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.0]
     buildable: false
     externals:
     - spec: rocprim@5.2.3
@@ -112,6 +122,8 @@ packages::
       prefix: /opt/rocm-5.4.3/
     - spec: rocprim@5.5.1
       prefix: /opt/rocm-5.5.1/
+    - spec: rocprim@5.6.0
+      prefix: /opt/rocm-5.6.0/
   cray-mpich:
     buildable: false
     externals:


### PR DESCRIPTION
This PR 
- adds latest ROCm and CCE releases
- fixes some wrong assumptions about system defaults
- removes a redundantly named spec
- updates camp spack package after recent release