### PR TITLE
Fix MPI support and Shared lib option in Caliper package

### DIFF
--- a/packages/caliper/package.py
+++ b/packages/caliper/package.py
@@ -148,9 +148,9 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def initconfig_mpi_entries(self):
         spec = self.spec
+        entries = super(Caliper, self).initconfig_mpi_entries()
 
-        entries = super(Umpire, self).initconfig_mpi_entries()
-        entries.append(cmake_cache_option("ENABLE_MPI", "+mpi" in spec))
+        entries.append(cmake_cache_option("WITH_MPI", "+mpi" in spec))
 
         return entries
 

--- a/packages/caliper/package.py
+++ b/packages/caliper/package.py
@@ -58,7 +58,7 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
     is_linux = sys.platform.startswith("linux")
     variant("shared", default=True, description="Build shared libraries")
     variant("adiak", default=True, description="Enable Adiak support")
-    variant("mpi", default=True, description="Enable MPI wrappers")
+    variant("mpi", default=True, description="Enable MPI support")
     # libunwind has some issues on Mac
     variant(
         "libunwind", default=sys.platform != "darwin", description="Enable stack unwind support"
@@ -121,7 +121,7 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "+fortran" in spec:
             entries.append(cmake_cache_option("WITH_FORTRAN", True))
 
-        entries.append(cmake_cache_option("BUILD_SHARED_LIBS", True))
+        entries.append(cmake_cache_option("BUILD_SHARED_LIBS", "+shared" in spec ))
         entries.append(cmake_cache_option("BUILD_TESTING", "+tests" in spec ))
         entries.append(cmake_cache_option("BUILD_DOCS", False))
         entries.append(cmake_cache_path("PYTHON_EXECUTABLE", spec["python"].command.path))
@@ -143,6 +143,14 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("WITH_ROCTX", True))
             hip_for_radiuss_projects(entries, spec, compiler)
             #entries.append(cmake_cache_option("ROCM_ROOT_DIR", "/usr/"))
+
+        return entries
+
+    def initconfig_mpi_entries(self):
+        spec = self.spec
+
+        entries = super(Umpire, self).initconfig_mpi_entries()
+        entries.append(cmake_cache_option("ENABLE_MPI", "+mpi" in spec))
 
         return entries
 


### PR DESCRIPTION
Solves #75

@aaroncblack, the fix here is only slightly different that your suggested changes.

Please note that I am working on integrating our local packages to spack. It’s essentially ready. If you want to test it, you can use the `llnl/radiuss-packages-update` branch in Spack.

Warning !
This is tested here: https://github.com/LLNL/Caliper/pull/507
Test are passing except on Tioga. I suspect our MPI setup for tioga may be wrong (in https://github.com/LLNL/radiuss-spack-configs/blob/main/toss_4_x86_64_ib_cray/packages.yaml). I think the Caliper package itself is OK.