### PR TITLE
Add specs for latest intel compilers

### DIFF
--- a/toss_4_x86_64_ib/compilers.yaml
+++ b/toss_4_x86_64_ib/compilers.yaml
@@ -192,6 +192,35 @@ compilers::
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: intel@=2023.2.1
+    paths:
+      cc: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/icx
+      cxx: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/icpx
+      f77: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/ifx
+      fc: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2023.2.1.gcc.10.3.1
+    paths:
+      cc: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/icx
+      cxx: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/icpx
+      f77: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/ifx
+      fc: /usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/ifx
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-10.3.1
+      fflags: -gcc-name=/usr/tce/packages/gcc/gcc-10.3.1/bin/gcc
+    operating_system: rhel8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
     spec: clang@=14.0.6
     paths:
       cc: /usr/tce/packages/clang/clang-14.0.6/bin/clang


### PR DESCRIPTION
intel-2023.2.1 works better than intel-2022.1.0. I want to move to that for CI testing.

We can probably get rid of TOSS3 files since LC no longer has any TOSS3 systems. We can do that here or in another PR.