### PR TITLE
Woptim/fix mpi exec flag

### DIFF
--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -77,13 +77,13 @@ def mpi_for_radiuss_projects(options, spec):
             mpiexec = os.path.join(spec["mpi"].prefix.bin, "mpiexec")
 
     if not os.path.exists(mpiexec):
-        msg = "Unable to determine MPIEXEC, %s tests may fail" % self.name
+        msg = "Unable to determine MPIEXEC, tests may fail"
         entries.append("# {0}\n".format(msg))
         tty.warn(msg)
     else:
         # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
         # vs the older versions which expect MPIEXEC
-        if self.spec["cmake"].satisfies("@3.10:"):
+        if spec["cmake"].satisfies("@3.10:"):
             entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", mpiexec))
         else:
             entries.append(cmake_cache_path("MPIEXEC", mpiexec))

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -9,6 +9,8 @@ import re
 
 from spack.package import *
 
+import llnl.util.tty as tty
+
 
 def spec_uses_toolchain(spec):
     gcc_toolchain_regex = re.compile(".*gcc-toolchain.*")
@@ -35,6 +37,62 @@ def hip_repair_cache(options, spec):
             glob.glob("{}/lib/clang/*/include".format(spec["llvm-amdgpu"].prefix))[0],
         )
     )
+
+def mpi_for_radiuss_projects(options, spec):
+    # Machines with cray-mpich have a slurm wrapper arround flux, to use it we
+    # duplicate the MPI handling from CachedCMakePackage. This change will be
+    # applied directly in the CachedCMakePackage when pushed to upstream Spack.
+    if not spec.satisfies("^mpi"):
+        return []
+
+    entries = [
+        "#------------------{0}".format("-" * 60),
+        "# MPI",
+        "#------------------{0}\n".format("-" * 60),
+    ]
+
+    entries.append(cmake_cache_option("ENABLE_MPI", "+mpi" in spec))
+
+    entries.append(cmake_cache_path("MPI_C_COMPILER", spec["mpi"].mpicc))
+    entries.append(cmake_cache_path("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
+    entries.append(cmake_cache_path("MPI_Fortran_COMPILER", spec["mpi"].mpifc))
+
+    # Check for slurm
+    using_slurm = False
+    # RADIUSS Spack Configs change:
+    slurm_checks = ["+slurm", "schedulers=slurm", "process_managers=slurm", "cray-mpich"]
+    if any(spec["mpi"].satisfies(variant) for variant in slurm_checks):
+        using_slurm = True
+
+    # Determine MPIEXEC
+    if using_slurm:
+        if spec["mpi"].external:
+            # Heuristic until we have dependents on externals
+            mpiexec = "/usr/bin/srun"
+        else:
+            mpiexec = os.path.join(spec["slurm"].prefix.bin, "srun")
+    else:
+        mpiexec = os.path.join(spec["mpi"].prefix.bin, "mpirun")
+        if not os.path.exists(mpiexec):
+            mpiexec = os.path.join(spec["mpi"].prefix.bin, "mpiexec")
+
+    if not os.path.exists(mpiexec):
+        msg = "Unable to determine MPIEXEC, %s tests may fail" % self.name
+        entries.append("# {0}\n".format(msg))
+        tty.warn(msg)
+    else:
+        # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
+        # vs the older versions which expect MPIEXEC
+        if self.spec["cmake"].satisfies("@3.10:"):
+            entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", mpiexec))
+        else:
+            entries.append(cmake_cache_path("MPIEXEC", mpiexec))
+
+    # Determine MPIEXEC_NUMPROC_FLAG
+    if using_slurm:
+        entries.append(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-n"))
+    else:
+        entries.append(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-np"))
 
 def hip_for_radiuss_projects(options, spec, compiler):
     # Here is what is typically needed for radiuss projects when building with rocm

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -204,7 +204,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         entries = []
 
-        mpi_for_radiuss_projects(entries, specs)
+        mpi_for_radiuss_projects(entries, spec)
 
         return entries
 

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -12,6 +12,8 @@ from .camp import hip_for_radiuss_projects
 from .camp import cuda_for_radiuss_projects
 from .camp import blt_link_helpers
 
+import llnl.util.tty as tty
+
 
 class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     """RAJA Performance Suite."""

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -236,13 +236,13 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
                 mpiexec = os.path.join(spec["mpi"].prefix.bin, "mpiexec")
 
         if not os.path.exists(mpiexec):
-            msg = "Unable to determine MPIEXEC, %s tests may fail" % self.pkg.name
+            msg = "Unable to determine MPIEXEC, %s tests may fail" % self.name
             entries.append("# {0}\n".format(msg))
             tty.warn(msg)
         else:
             # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
             # vs the older versions which expect MPIEXEC
-            if self.pkg.spec["cmake"].satisfies("@3.10:"):
+            if self.spec["cmake"].satisfies("@3.10:"):
                 entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", mpiexec))
             else:
                 entries.append(cmake_cache_path("MPIEXEC", mpiexec))

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -205,7 +205,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries = super(RajaPerf, self).initconfig_mpi_entries()
         entries.append(cmake_cache_option("ENABLE_MPI", "+mpi" in spec))
 
-        if spec["mpi"].satisfies("spectrum-mpi");
+        if spec["mpi"].satisfies("spectrum-mpi"):
             entries.append(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-n"))
 
         return entries

--- a/packages/raja_perf/package.py
+++ b/packages/raja_perf/package.py
@@ -205,6 +205,9 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries = super(RajaPerf, self).initconfig_mpi_entries()
         entries.append(cmake_cache_option("ENABLE_MPI", "+mpi" in spec))
 
+        if spec["mpi"].satisfies("spectrum-mpi");
+            entries.append(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-n"))
+
         return entries
 
     def initconfig_package_entries(self):

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -135,25 +135,43 @@ packages::
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%intel@=19.1.2 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%intel@=19.1.2.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
+    - spec: mvapich2@2.3.7%intel@=2021.6.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%intel@=2021.6.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
+    - spec: mvapich2@2.3.7%intel@=2022.1.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%intel@=2022.1.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
+    - spec: mvapich2@2.3.7%intel@=2023.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
+    - spec: mvapich2@2.3.7%intel@=2023.2.1.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
+    - spec: mvapich2@2.3.7%clang@=14.0.6 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%clang@=14.0.6.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
+    - spec: mvapich2@2.3.7%gcc@=10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%gcc@=11.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-11.2.1
-    - spec: mvapich2@2.3.7%gcc@10.3.1~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+    - spec: mvapich2@2.3.7%gcc@=12.1.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
         file_systems=lustre,nfs,ufs process_managers=slurm
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-12.1.1
   python:


### PR DESCRIPTION
This PR fixes the MPIEXEC_NUMPROCS_FLAG on Cray machines (tioga and corona, using cray-mpich).