### PR TITLE
terminal_title -> install_status + keep_werror: all

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,11 @@ config:
   # are that it precludes its use as a system package and its ability to be
   # pip installable.
   #
+  # In Spack environment files, chaining onto existing system Spack
+  # installations, the $env variable can be used to download, cache and build
+  # into user-writable paths that are relative to the currently active
+  # environment.
+  #
   # In any case, if the username is not already in the path, Spack will append
   # the value of `$user` in an attempt to avoid potential conflicts between
   # users in shared temporary spaces.
@@ -77,6 +82,10 @@ config:
   # Cache directory for already downloaded source tarballs and archived
   # repositories. This can be purged with `spack clean --downloads`.
   source_cache: $spack/var/spack/cache
+
+
+  ## Directory where spack managed environments are created and stored
+  # environments_root: $spack/var/spack/environments
 
 
   # Cache directory for miscellaneous files, like the package index.
@@ -179,7 +188,7 @@ config:
   # when Spack needs to manage its own package metadata and all operations are
   # expected to complete within the default time limit. The timeout should
   # therefore generally be left untouched.
-  db_lock_timeout: 3
+  db_lock_timeout: 60
 
 
   # How long to wait when attempting to modify a package (e.g. to install it).
@@ -210,11 +219,24 @@ config:
   # manipulation by unprivileged user (e.g. AFS)
   allow_sgid: true
 
-  # Whether to set the terminal title to display status information during
-  # building and installing packages. This gives information about Spack's
-  # current progress as well as the current and total number of packages.
-  terminal_title: false
+  # Whether to show status information during building and installing packages.
+  # This gives information about Spack's current progress as well as the current
+  # and total number of packages. Information is shown both in the terminal
+  # title and inline.
+  install_status: true
 
   # Number of seconds a buildcache's index.json is cached locally before probing
   # for updates, within a single Spack invocation. Defaults to 10 minutes.
   binary_index_ttl: 600
+
+  flags:
+    # Whether to keep -Werror flags active in package builds.
+    keep_werror: 'all'
+
+  # A mapping of aliases that can be used to define new commands. For instance,
+  # `sp: spec -I` will define a new command `sp` that will execute `spec` with
+  # the `-I` argument. Aliases cannot override existing commands.
+  aliases:
+    concretise: concretize
+    containerise: containerize
+    rm: remove


### PR DESCRIPTION
This PR updates the Spack config.yaml file:

- `terminal_title` -> `install_status` is a change of keyword name that was causing a warning.
- `keep_werror` is a new keyword aimed at controlling whether Spack should override the `-Werror` flag in packages build.
  - Spack default value is `none`, which consists in always overriding `-Werror`. I considered that `all` (keeping the `-Werror` flag) was more appropriate for our use.

@davidbeckingsale, do you agree with the second statement ?

@white238 same questions. Also, please note that I would like to merge this before #85.