### PR TITLE
[Woptim] protect compiler version in ci specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Please read [CONTRIBUTING.md](https://github.com/LLNL/radiuss-spack-configs/CONT
 
 ## Versioning
 
-version: 1.0.0
-
-TODO: Not even sure how to handle versioning here.
+### Tags nomenclature:
+Tags reflect the RAJA and Umpire latest release RADIUSS Spack Configs supports, together with the Spack reference that was used for vetting.
+We issue a tag as soon as one of the two parameter changes for the vetting of the main branch.
+We recommend using the same Spack as newer or older versions may not be compatible out of the box.
 
 ## Authors
 

--- a/docs/sphinx/user_guide/use_spack.rst
+++ b/docs/sphinx/user_guide/use_spack.rst
@@ -92,8 +92,16 @@ Main steps
     Create the ``.uberenv_config.json`` file in a directory that is a parent of
     the ``uberenv`` directory. Projects typically place the file in the
     top-level directory of its repository. Set your project package name, and
-    other parameters like Spack reference commit/tag (we suggest the latest
-    release tag).
+    other parameters like Spack reference commit/tag.
+
+    .. note::
+       We recommend using the `Spack`_ reference mentionned in `RADIUSS Spack
+       Configs`_ closest parent tag. In the `RADIUSS Spack Configs`_ history,
+       look for the tag that is the closest parent of the checkout commit. It
+       is made of the latest supported release version of `RAJA`_ and `Umpire`_
+       together with the `Spack`_ reference used to vet `RADIUSS Spack
+       Configs`_. Newer or older `Spack`_ references may not work out of the
+       box.
 
 #. Add RADIUSS Spack Configs submodule.
 

--- a/gitlab/radiuss-jobs/corona.yml
+++ b/gitlab/radiuss-jobs/corona.yml
@@ -7,5 +7,5 @@
 
 rocmcc_5_7_0_hip:
   variables:
-    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %rocmcc@5.7.0 ^hip@5.7.0 ${PROJECT_CORONA_DEPS}"
+    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %rocmcc@=5.7.0 ^hip@5.7.0 ${PROJECT_CORONA_DEPS}"
   extends: .job_on_corona

--- a/gitlab/radiuss-jobs/lassen.yml
+++ b/gitlab/radiuss-jobs/lassen.yml
@@ -7,30 +7,30 @@
 
 clang_12_0_1_ibm_gcc_8_3_1_cuda_10_1_243:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@12.0.1.ibm.gcc.8.3.1 ^cuda@10.1.243+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@=12.0.1.ibm.gcc.8.3.1 ^cuda@10.1.243+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
   extends: .job_on_lassen
 
 clang_12_0_1_gcc_8_3_1_cuda_11_2_0:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@12.0.1.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@=12.0.1.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
     MODULE_LIST: "cuda/11.2.0"
   extends: .job_on_lassen
 
 clang_14_0_5_gcc_8_3_1_cuda_11_7_0:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@14.0.5.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@=14.0.5.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 
 xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@16.1.1.12.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@=16.1.1.12.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
     MODULE_LIST: "cuda/11.2.0"
   extends: .job_on_lassen
 
 gcc_8_3_1_cuda_11_7_0:
   variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %gcc@8.3.1 ^cuda@11.7.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %gcc@=8.3.1 ^cuda@11.7.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
     MODULE_LIST: "cuda/11.7.0"
   extends: .job_on_lassen
 

--- a/gitlab/radiuss-jobs/poodle.yml
+++ b/gitlab/radiuss-jobs/poodle.yml
@@ -7,21 +7,21 @@
 
 intel_19_1_2_gcc_10_3_1:
   variables:
-    SPEC: "${PROJECT_POODLE_VARIANTS} %intel@19.1.2.gcc.10.3.1 ${PROJECT_POODLE_DEPS}"
+    SPEC: "${PROJECT_POODLE_VARIANTS} %intel@=19.1.2.gcc.10.3.1 ${PROJECT_POODLE_DEPS}"
   extends: .job_on_poodle
 
 intel_2022_1_0:
   variables:
-    SPEC: "${PROJECT_POODLE_VARIANTS} %intel@2022.1.0 ${PROJECT_POODLE_DEPS}"
+    SPEC: "${PROJECT_POODLE_VARIANTS} %intel@=2022.1.0 ${PROJECT_POODLE_DEPS}"
   extends: .job_on_poodle
 
 clang_14_0_6:
   variables:
-    SPEC: "${PROJECT_POODLE_VARIANTS} %clang@14.0.6 ${PROJECT_POODLE_DEPS}"
+    SPEC: "${PROJECT_POODLE_VARIANTS} %clang@=14.0.6 ${PROJECT_POODLE_DEPS}"
   extends: .job_on_poodle
 
 gcc_10_3_1:
   variables:
-    SPEC: "${PROJECT_POODLE_VARIANTS} %gcc@10.3.1 ${PROJECT_POODLE_DEPS}"
+    SPEC: "${PROJECT_POODLE_VARIANTS} %gcc@=10.3.1 ${PROJECT_POODLE_DEPS}"
   extends: .job_on_poodle
 

--- a/gitlab/radiuss-jobs/ruby.yml
+++ b/gitlab/radiuss-jobs/ruby.yml
@@ -7,21 +7,21 @@
 
 intel_19_1_2_gcc_10_3_1:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@19.1.2.gcc.10.3.1 ${PROJECT_RUBY_DEPS}"
+    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=19.1.2.gcc.10.3.1 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 
 intel_2022_1_0:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@2022.1.0 ${PROJECT_RUBY_DEPS}"
+    SPEC: "${PROJECT_RUBY_VARIANTS} %intel@=2022.1.0 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 
 clang_14_0_6:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %clang@14.0.6 ${PROJECT_RUBY_DEPS}"
+    SPEC: "${PROJECT_RUBY_VARIANTS} %clang@=14.0.6 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 
 gcc_10_3_1:
   variables:
-    SPEC: "${PROJECT_RUBY_VARIANTS} %gcc@10.3.1 ${PROJECT_RUBY_DEPS}"
+    SPEC: "${PROJECT_RUBY_VARIANTS} %gcc@=10.3.1 ${PROJECT_RUBY_DEPS}"
   extends: .job_on_ruby
 

--- a/gitlab/radiuss-jobs/tioga.yml
+++ b/gitlab/radiuss-jobs/tioga.yml
@@ -7,10 +7,10 @@
 
 rocmcc_5_7_1_hip:
   variables:
-    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@5.7.1 ^hip@5.7.1 ${PROJECT_TIOGA_DEPS}"
+    SPEC: "${PROJECT_TIOGA_VARIANTS} +rocm amdgpu_target=gfx90a %rocmcc@=5.7.1 ^hip@5.7.1 ${PROJECT_TIOGA_DEPS}"
   extends: .job_on_tioga
 
 cce_16_0_1:
   variables:
-    SPEC: "${PROJECT_TIOGA_VARIANTS} %cce@16.0.1 ${PROJECT_TIOGA_DEPS}"
+    SPEC: "${PROJECT_TIOGA_VARIANTS} %cce@=16.0.1 ${PROJECT_TIOGA_DEPS}"
   extends: .job_on_tioga


### PR DESCRIPTION
In an attempt to update Spack, we strengthened the CI specs by enforcing the exact compiler version we want.

We vetted this branch to work with develop-2024-02-18.

This branch has been chosen because it integrates the fix for https://github.com/spack/spack/issues/42679 (https://github.com/spack/spack/pull/42682), but does not have https://github.com/spack/spack/issues/42655 which revealed another issue.