### PR TITLE
Use llvm-amdgpu instead of hip to determine ROCM_PATH

### DIFF
--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -25,7 +25,7 @@ def spec_uses_gccname(spec):
 def hip_for_radiuss_projects(options, spec, compiler):
     # Here is what is typically needed for radiuss projects when building with rocm
     rocm_root = dirname(spec["llvm-amdgpu"].prefix)
-    options.append(cmake_cache_path("ROCM_ROOT_DIR", rocm_root))
+    options.append(cmake_cache_path("ROCM_PATH", rocm_root))
 
     # there is only one dir like this, but the version component is unknown
     options.append(
@@ -191,7 +191,7 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
         options.append(self.define_from_variant("ENABLE_HIP", "rocm"))
         if spec.satisfies("+rocm"):
             rocm_root = dirname(spec["llvm-amdgpu"].prefix)
-            options.append("-DROCM_ROOT_DIR={0}".format(rocm_root))
+            options.append("-DROCM_PATH={0}".format(rocm_root))
 
             # there is only one dir like this, but the version component is unknown
             options.append(

--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -6,6 +6,8 @@
 import glob
 import re
 
+from os.path import dirname
+
 from spack.package import *
 from spack.util.executable import which_string
 
@@ -22,8 +24,7 @@ def spec_uses_gccname(spec):
 
 def hip_for_radiuss_projects(options, spec, compiler):
     # Here is what is typically needed for radiuss projects when building with rocm
-    hip_root = spec["hip"].prefix
-    rocm_root = hip_root + "/.."
+    rocm_root = dirname(spec["llvm-amdgpu"].prefix)
     options.append(cmake_cache_path("ROCM_ROOT_DIR", rocm_root))
 
     # there is only one dir like this, but the version component is unknown
@@ -189,7 +190,8 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
         options.append(self.define_from_variant("ENABLE_HIP", "rocm"))
         if spec.satisfies("+rocm"):
-            options.append("-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix))
+            rocm_root = dirname(spec["llvm-amdgpu"].prefix)
+            options.append("-DROCM_ROOT_DIR={0}".format(rocm_root))
 
             # there is only one dir like this, but the version component is unknown
             options.append(

--- a/toss_4_x86_64_ib_cray/spack.yaml
+++ b/toss_4_x86_64_ib_cray/spack.yaml
@@ -379,11 +379,11 @@ spack:
       - spec: hip@5.7.1%rocmcc@5.7.1
         prefix: /opt/rocm-5.7.1/hip
       - spec: hip@6.1.1%rocmcc@6.1.1
-        prefix: /opt/rocm-6.1.1/hip
+        prefix: /opt/rocm-6.1.1
       - spec: hip@6.1.2%rocmcc@6.1.2
-        prefix: /opt/rocm-6.1.2/hip
+        prefix: /opt/rocm-6.1.2
       - spec: hip@6.2.0%rocmcc@6.2.0
-        prefix: /opt/rocm-6.2.0/hip
+        prefix: /opt/rocm-6.2.0
     llvm-amdgpu:
       version: [5.2.3, 5.3.0, 5.4.1, 5.4.3, 5.5.1, 5.6.1, 5.7.0, 5.7.1, 6.1.1, 6.1.2, 6.2.0]
       buildable: false


### PR DESCRIPTION
This PR:
- Incorporating [suggestion ](https://github.com/LLNL/radiuss-spack-configs/issues/113#issue-2622419646)made by @chapman39, modifies `hip_for_radiuss_projects()` to use `llvm-amdgpu` to determine `ROCM_PATH` instead of `hip`, whose directory may or may not exist depending on pre or post `rocm 6.x.x` version
  - For future reference: `hip`, `hsa-rocr-dev`, and `llvm-amdgpu` are the current three dependencies of `ROCmPackage` : https://github.com/spack/spack/blob/bf11fb037b799d8643d096dfb0991c33b801a716/lib/spack/spack/build_systems/rocm.py#L144-L146

Closes #111

Relates to LLNL/axom#1461