### PR TITLE
Add zlib as a zlib-api provider

### DIFF
--- a/toss_4_x86_64_ib/corona/packages.yaml
+++ b/toss_4_x86_64_ib/corona/packages.yaml
@@ -6,6 +6,7 @@ packages::
       blas: [openblas]
       lapack: [netlib-lapack]
       mpi: [mvapich2]
+      zlib-api: [zlib]
   cmake:
     version: [3.23.1, 3.22.4, 3.21.1, 3.19.2, 3.14.5]
     buildable: false

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -8,6 +8,7 @@ packages::
       blas: [openblas]
       lapack: [netlib-lapack]
       mpi: [mvapich2]
+      zlib-api: [zlib]
     require:
     - spec: '^blt%oneapi'
       when: '%oneapi ^blt'

--- a/toss_4_x86_64_ib/poodle/packages.yaml
+++ b/toss_4_x86_64_ib/poodle/packages.yaml
@@ -13,6 +13,7 @@ packages::
       blas: [openblas]
       lapack: [netlib-lapack]
       mpi: [mvapich2]
+      zlib-api: [zlib]
   gcc-runtime:
     require:
     - '%gcc'

--- a/toss_4_x86_64_ib/ruby/packages.yaml
+++ b/toss_4_x86_64_ib/ruby/packages.yaml
@@ -13,6 +13,7 @@ packages::
       blas: [openblas]
       lapack: [netlib-lapack]
       mpi: [mvapich2]
+      zlib-api: [zlib]
   gcc-runtime:
     require:
     - '%gcc'

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -6,6 +6,7 @@ packages::
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
       mpi: [cray-mpich]
+      zlib-api: [zlib]
   cmake:
     version: [3.24.2, 3.23.1, 3.22.4, 3.21.1, 3.19.2, 3.14.5]
     buildable: false

--- a/toss_4_x86_64_ib_cray/tioga/packages.yaml
+++ b/toss_4_x86_64_ib_cray/tioga/packages.yaml
@@ -6,6 +6,7 @@ packages::
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
       mpi: [cray-mpich]
+      zlib-api: [zlib]
   cmake:
     version: [3.24.2, 3.23.1, 3.22.4, 3.21.1, 3.19.2, 3.14.5]
     buildable: false


### PR DESCRIPTION
Add `zlib` as a `zlib-api` provider. This fixes an issue where spack was building `zlib-ng` for a package that needed a `zlib-api` provider instead of using the declared external `zlib`.