### PR TITLE
Lapack on lassen path issues

### DIFF
--- a/blueos_3_ppc64le_ib/lassen/packages.yaml
+++ b/blueos_3_ppc64le_ib/lassen/packages.yaml
@@ -191,12 +191,12 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -clang-ibm-16.0.6-gcc-8.3.1
     #- spec: netlib-lapack@3.    %clang@=16.0.6.ibm.cuda.11.8.0.gcc.11.2.1
     #  prefix: /usr/tce/packages/lapack/lapack--clang-ibm-16.0.6-cuda-11.8.0-gcc-11.2.1
-    - spec: netlib-lapack@3.8.0%gcc@=4.9.3
-      prefix: /usr/tce/packages/lapack/lapack-3.8.0-P9-gcc-4.9.3
-    - spec: netlib-lapack@3.9.0%gcc@=8.3.1
-      prefix: /usr/tce/packages/lapack/lapack-3.9.0-P9-gcc-7.3.1
-    - spec: netlib-lapack@3.11.0%gcc@=11.2.1
-      prefix: /usr/tce/packages/lapack/lapack-3.11.0-P9-gcc-11.2.1
+    # - spec: netlib-lapack@3.8.0%gcc@=4.9.3
+    #   prefix: /usr/tce/packages/lapack/lapack-3.8.0-P9-gcc-4.9.3
+    # - spec: netlib-lapack@3.9.0%gcc@=8.3.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.9.0-P9-gcc-7.3.1
+    # - spec: netlib-lapack@3.11.0%gcc@=11.2.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.11.0-P9-gcc-11.2.1
     #- spec: netlib-lapack@3.    %xl@=16.1.1.10
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2021.09.22
     #- spec: netlib-lapack@3.    %xl@=16.1.1.10.gcc.8.3.1
@@ -207,10 +207,10 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2022.08.19
     #- spec: netlib-lapack@3.    %xl@=16.1.1.12.gcc.8.3.1
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2022.08.19-gcc-8.3.1
-    - spec: netlib-lapack@3.12.0%xl@=16.1.1.14
-      prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28
-    - spec: netlib-lapack@3.12.0%xl@=16.1.1.14.gcc.8.3.1
-      prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28-gcc-8.3.1
+    # - spec: netlib-lapack@3.12.0%xl@=16.1.1.14
+    #   prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28
+    # - spec: netlib-lapack@3.12.0%xl@=16.1.1.14.gcc.8.3.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28-gcc-8.3.1
     #- spec: netlib-lapack@%xl@=beta2019.06.20
     #  prefix: /usr/tce/packages/lapack/lapack--xl-beta-2019.06.20
     #- spec: netlib-lapack@%pgi@=19.10
@@ -225,7 +225,7 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack--pgi-22.11
     #- spec: netlib-lapack@%pgi@=23.1
     #  prefix: /usr/tce/packages/lapack/lapack--pgi-23.1
-    - spec: netlib-lapack
+    - spec: netlib-lapack@3.9.0
       prefix: /usr/tcetmp/packages/lapack/lapack-3.9.0-xl-2020.11.12
 
   # System level packages to not build

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -193,12 +193,12 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -clang-ibm-16.0.6-gcc-8.3.1
     #- spec: netlib-lapack@3.    %clang@=16.0.6.ibm.cuda.11.8.0.gcc.11.2.1
     #  prefix: /usr/tce/packages/lapack/lapack--clang-ibm-16.0.6-cuda-11.8.0-gcc-11.2.1
-    - spec: netlib-lapack@3.8.0%gcc@=4.9.3
-      prefix: /usr/tce/packages/lapack/lapack-3.8.0-P9-gcc-4.9.3
-    - spec: netlib-lapack@3.9.0%gcc@=8.3.1
-      prefix: /usr/tce/packages/lapack/lapack-3.9.0-P9-gcc-7.3.1
-    - spec: netlib-lapack@3.11.0%gcc@=11.2.1
-      prefix: /usr/tce/packages/lapack/lapack-3.11.0-P9-gcc-11.2.1
+    # - spec: netlib-lapack@3.8.0%gcc@=4.9.3
+    #   prefix: /usr/tce/packages/lapack/lapack-3.8.0-P9-gcc-4.9.3
+    # - spec: netlib-lapack@3.9.0%gcc@=8.3.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.9.0-P9-gcc-7.3.1
+    # - spec: netlib-lapack@3.11.0%gcc@=11.2.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.11.0-P9-gcc-11.2.1
     #- spec: netlib-lapack@3.    %xl@=16.1.1.10
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2021.09.22
     #- spec: netlib-lapack@3.    %xl@=16.1.1.10.gcc.8.3.1
@@ -209,10 +209,10 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2022.08.19
     #- spec: netlib-lapack@3.    %xl@=16.1.1.12.gcc.8.3.1
     #  prefix: /usr/tce/packages/lapack/lapack-3.    -xl-2022.08.19-gcc-8.3.1
-    - spec: netlib-lapack@3.12.0%xl@=16.1.1.14
-      prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28
-    - spec: netlib-lapack@3.12.0%xl@=16.1.1.14.gcc.8.3.1
-      prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28-gcc-8.3.1
+    # - spec: netlib-lapack@3.12.0%xl@=16.1.1.14
+    #   prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28
+    # - spec: netlib-lapack@3.12.0%xl@=16.1.1.14.gcc.8.3.1
+    #   prefix: /usr/tce/packages/lapack/lapack-3.12.0-xl-2023.06.28-gcc-8.3.1
     #- spec: netlib-lapack@%xl@=beta2019.06.20
     #  prefix: /usr/tce/packages/lapack/lapack--xl-beta-2019.06.20
     #- spec: netlib-lapack@%pgi@=19.10
@@ -227,7 +227,7 @@ packages::
     #  prefix: /usr/tce/packages/lapack/lapack--pgi-22.11
     #- spec: netlib-lapack@%pgi@=23.1
     #  prefix: /usr/tce/packages/lapack/lapack--pgi-23.1
-    - spec: netlib-lapack
+    - spec: netlib-lapack@3.9.0
       prefix: /usr/tcetmp/packages/lapack/lapack-3.9.0-xl-2020.11.12
 
   # System level packages to not build


### PR DESCRIPTION
- The lapack packages don't exist on lassen at `/usr/tce/packages/lapack/` (though there are some at `/usr/tcetmp/packages/lapack`, so not sure if you want to use those?). 
- Add version number to lapack spec at `/usr/tcetmp/packages/lapack/`, to avoid `Warning: cannot use the external spec netlib-lapack: needs a concrete version`