### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/packages/camp/package.py
+++ b/packages/camp/package.py
@@ -58,7 +58,7 @@ def cuda_for_radiuss_projects(options, spec):
     if spec_uses_toolchain(spec):
         cuda_flags.append("-Xcompiler {}".format(spec_uses_toolchain(spec)[0]))
 
-    if spec.satisfies("%gcc@8.1: target=ppc64le"):
+    if spec.satisfies("target=ppc64le %gcc@8.1:"):
         cuda_flags.append("-Xcompiler -mno-float128")
 
     options.append(cmake_cache_string("CMAKE_CUDA_FLAGS", " ".join(cuda_flags)))

--- a/toss_4_x86_64_ib/corona/packages.yaml
+++ b/toss_4_x86_64_ib/corona/packages.yaml
@@ -184,44 +184,44 @@ packages::
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.3.7%intel@=19.1.2 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=19.1.2.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=2021.6.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%intel@=2021.6.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%clang@=14.0.6 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%clang@=14.0.6.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%gcc@=10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
-    - spec: mvapich2@2.3.7%gcc@=11.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=11.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-11.2.1
-    - spec: mvapich2@2.3.7%gcc@=12.1.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=12.1.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-12.1.1
 
   autoconf:

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -199,44 +199,44 @@ packages::
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.3.7%intel@=19.1.2 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=19.1.2.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=2021.6.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%intel@=2021.6.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%clang@=14.0.6 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%clang@=14.0.6.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%gcc@=10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
-    - spec: mvapich2@2.3.7%gcc@=11.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=11.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-11.2.1
-    - spec: mvapich2@2.3.7%gcc@=12.1.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=12.1.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-12.1.1
 
   autoconf:

--- a/toss_4_x86_64_ib/poodle/packages.yaml
+++ b/toss_4_x86_64_ib/poodle/packages.yaml
@@ -37,44 +37,44 @@ packages::
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.3.7%intel@=19.1.2 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=19.1.2.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=2021.6.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%intel@=2021.6.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%clang@=14.0.6 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%clang@=14.0.6.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%gcc@=10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
-    - spec: mvapich2@2.3.7%gcc@=11.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=11.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-11.2.1
-    - spec: mvapich2@2.3.7%gcc@=12.1.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=12.1.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-12.1.1
 
   autoconf:

--- a/toss_4_x86_64_ib/ruby/packages.yaml
+++ b/toss_4_x86_64_ib/ruby/packages.yaml
@@ -37,44 +37,44 @@ packages::
   mvapich2:
     buildable: false
     externals:
-    - spec: mvapich2@2.3.7%intel@=19.1.2 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=19.1.2.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=19.1.2.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-19.1.2
-    - spec: mvapich2@2.3.7%intel@=2021.6.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%intel@=2021.6.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %intel@=2021.6.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2022.1.0.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2022.1.0.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%oneapi@=2023.2.1.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %oneapi@=2023.2.1.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1
-    - spec: mvapich2@2.3.7%clang@=14.0.6 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%clang@=14.0.6.gcc.10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %clang@=14.0.6.gcc.10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-    - spec: mvapich2@2.3.7%gcc@=10.3.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=10.3.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
-    - spec: mvapich2@2.3.7%gcc@=11.2.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=11.2.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-11.2.1
-    - spec: mvapich2@2.3.7%gcc@=12.1.1 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
-        file_systems=lustre,nfs,ufs process_managers=slurm
+    - spec: mvapich2@2.3.7 ~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        file_systems=lustre,nfs,ufs process_managers=slurm %gcc@=12.1.1
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-12.1.1
 
   autoconf:


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
