### PR TITLE
Minor fixes and add quandary package

### DIFF
--- a/blueos_3_ppc64le_ib/lassen/packages.yaml
+++ b/blueos_3_ppc64le_ib/lassen/packages.yaml
@@ -329,10 +329,10 @@ packages::
       prefix: /usr
   python:
     buildable: false
-    version: [3.8.2]
+    version: [3.11.5]
     externals:
-    - spec: python@3.8.2
-      prefix: /usr/tce/packages/python/python-3.8.2
+    - spec: python@3.11.5
+      prefix: /usr/apps/python-3.11.5
   readline:
     buildable: false
     externals:

--- a/blueos_3_ppc64le_ib/packages.yaml
+++ b/blueos_3_ppc64le_ib/packages.yaml
@@ -331,10 +331,10 @@ packages::
       prefix: /usr
   python:
     buildable: false
-    version: [3.8.2]
+    version: [3.11.5]
     externals:
-    - spec: python@3.8.2
-      prefix: /usr/tce/packages/python/python-3.8.2
+    - spec: python@3.11.5
+      prefix: /usr/apps/python-3.11.5
   readline:
     buildable: false
     externals:

--- a/gitlab/radiuss-jobs/lassen.yml
+++ b/gitlab/radiuss-jobs/lassen.yml
@@ -8,7 +8,7 @@
 clang_12_0_1_ibm_gcc_8_3_1_cuda_11_2_0:
   variables:
     SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %clang@=12.0.1.ibm.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
-    MODULE_LIST: "cuda/10.1.243"
+    MODULE_LIST: "cuda/11.2.0"
   extends: .job_on_lassen
 
 clang_12_0_1_gcc_8_3_1_cuda_11_2_0:

--- a/packages/quandary/package.py
+++ b/packages/quandary/package.py
@@ -1,0 +1,67 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Quandary(CachedCMakePackage, CudaPackage, ROCmPackage):
+    """Optimal control for open quantum systems"""
+
+    homepage = "https://github.com/LLNL/quandary"
+    git = "https://github.com/LLNL/quandary.git"
+
+    maintainers("steffi7574", "tdrwenski")
+
+    license("MIT", checked_by="tdrwenski")
+
+    version("main", branch="main")
+
+    depends_on("cxx", type="build")
+
+    depends_on("petsc~hypre~metis~fortran")
+    depends_on("petsc+debug", when="+debug")
+    depends_on("slepc", when="+slepc")
+
+    depends_on("blt", type="build")
+    conflicts("^blt@:0.3.6", when="+rocm")
+
+    with when("+rocm"):
+        depends_on("petsc+rocm")
+        for arch_ in ROCmPackage.amdgpu_targets:
+            depends_on("petsc amdgpu_target={0}".format(arch_), when="amdgpu_target={0}".format(arch_))
+
+    with when("+cuda"):
+        depends_on("petsc+cuda")
+        for sm_ in CudaPackage.cuda_arch_values:
+            depends_on("petsc cuda_arch={0}".format(sm_), when="cuda_arch={0}".format(sm_))
+
+    variant("slepc", default=False, description="Build with Slepc library")
+    variant("debug", default=False, description="Debug mode")
+
+    variant("test", default=False, description="Add dependencies needed for testing")
+
+    with when("+test"):
+        depends_on("python", type="run")
+        depends_on("py-pip", type="run")
+        depends_on("mpi", type="run")
+
+    build_targets = ["all"]
+    install_targets = ["install"]
+
+
+    def initconfig_package_entries(self):
+        spec = self.spec
+        entries = []
+
+        entries.append(cmake_cache_path("BLT_SOURCE_DIR", spec["blt"].prefix))
+
+        return entries
+
+
+    def cmake_args(self):
+        args = []
+        if '+slepc' in self.spec:
+            args.append('-DWITH_SLEPC=ON')
+        return args

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -95,6 +95,12 @@ packages::
       prefix: /opt/rocm-6.2.4
     - spec: hipblas@6.3.0%rocmcc@6.3.0
       prefix: /opt/rocm-6.3.0
+  hipblas-common:
+    version: [6.3.0]
+    buildable: false
+    externals:
+    - spec: hipblas-common@6.3.0%rocmcc@6.3.0
+      prefix: /opt/rocm-6.3.0
   hipsolver:
     version: [5.2.3, 5.3.0, 5.4.3, 5.5.1, 5.6.1, 5.7.1, 6.1.2, 6.2.4, 6.3.0]
     buildable: false

--- a/toss_4_x86_64_ib_cray/tioga/packages.yaml
+++ b/toss_4_x86_64_ib_cray/tioga/packages.yaml
@@ -95,6 +95,12 @@ packages::
       prefix: /opt/rocm-6.2.4
     - spec: hipblas@6.3.0%rocmcc@6.3.0
       prefix: /opt/rocm-6.3.0
+  hipblas-common:
+    version: [6.3.0]
+    buildable: false
+    externals:
+    - spec: hipblas-common@6.3.0%rocmcc@6.3.0
+      prefix: /opt/rocm-6.3.0
   hipsolver:
     version: [5.2.3, 5.3.0, 5.4.3, 5.5.1, 5.6.1, 5.7.1, 6.1.2, 6.2.4, 6.3.0]
     buildable: false


### PR DESCRIPTION
A few more fixes that I needed to get quandary and petsc working that I don't see in v2025.03.0 yet

- Add hipblas-common (needed for hipblas and petsc when hipblas >=6.3.0)
- Fix typo in cuda version in lassen job to match spec
- Update python version on lassen
- Add quandary spack package