### PR TITLE
Update fmt Version to Handle c++20

### DIFF
--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -294,9 +294,9 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("sqlite", when="+sqlite_experimental")
     depends_on("mpi", when="+mpi")
 
-    depends_on("fmt@9.1:11.0", when="@2024.02.0:")
+    depends_on("fmt@9.1:11.1.0", when="@2024.02.0:")
     # For some reason, we need c++ 17 explicitly only with intel
-    depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1:11.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -294,9 +294,9 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("sqlite", when="+sqlite_experimental")
     depends_on("mpi", when="+mpi")
 
-    depends_on("fmt@9.1:11.1.0", when="@2024.02.0:")
+    depends_on("fmt@9.1:12.1.0", when="@2024.02.0:")
     # For some reason, we need c++ 17 explicitly only with intel
-    depends_on("fmt@9.1:11.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1:12.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -295,7 +295,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("fmt@9.1:12.1.0", when="@2024.02.0:")
-    # For some reason, we need c++ 17 explicitly only with intel
+    # For some reason, we need c++ 17 only with intel
     depends_on("fmt@9.1:12.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -296,7 +296,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("fmt@12.1.0", when="@2026:")
     depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
-    # For some reason, we need c++ 17 only with intel
+    # We need c++ 17 only with intel
     depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -294,9 +294,10 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("sqlite", when="+sqlite_experimental")
     depends_on("mpi", when="+mpi")
 
-    depends_on("fmt@9.1:12.1.0", when="@2024.02.0:")
+    depends_on("fmt@12.1.0", when="@2026:")
+    depends_on("fmt@9.1:11.1.0", when="@2024.02.0:")
     # For some reason, we need c++ 17 only with intel
-    depends_on("fmt@9.1:12.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1:11.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -295,7 +295,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("fmt@12.1.0", when="@2026:")
-    depends_on("fmt@9.1:11.0", when="@2024.02.0:")
+    depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
     # For some reason, we need c++ 17 only with intel
     depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -295,9 +295,9 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
 
     depends_on("fmt@12.1.0", when="@2026:")
-    depends_on("fmt@9.1:11.1.0", when="@2024.02.0:")
+    depends_on("fmt@9.1:11.0", when="@2024.02.0:")
     # For some reason, we need c++ 17 only with intel
-    depends_on("fmt@9.1:11.1.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
+    depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):
         with when("+cuda"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -296,7 +296,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("fmt@12.1.0", when="@2026:")
     depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
-    # We need c++ 17 only with intel
+    # We need c++ 17 only with intel.
     depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -296,7 +296,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("fmt@12.1.0", when="@2026:")
     depends_on("fmt@9.1:11.0", when="@2024.02.0:2025")
-    # We need c++ 17 only with intel.
+    # We need c++ 17 only with intel
     depends_on("fmt@9.1:11.0 cxxstd=17", when="@2024.02.0: %intel@19.1")
 
     with when("@5.0.0:"):


### PR DESCRIPTION
In process of updating Umpire to C++20. Along the way, I discovered fmt doesn't handle the `consteval` stuff correctly and it seems an updated version of fmt is needed. I'd like to test with this change to see if this will indeed fix the errors I see in the Umpire CI.