### PR TITLE
Require cmake/3.25 or Newer For Next Umpire Releases

### DIFF
--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -254,6 +254,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build", when="+fortran")
 
+    depends_on("cmake@3.25:", when="@develop", type="build")
     depends_on("cmake@3.25:", when="@2026:", type="build")
     depends_on("cmake@3.23:", when="@2024.07.0:", type="build")
     depends_on("cmake@3.23:", when="@2022.10.0: +rocm", type="build")

--- a/spack_repo/llnl_radiuss/packages/umpire/package.py
+++ b/spack_repo/llnl_radiuss/packages/umpire/package.py
@@ -254,6 +254,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build", when="+fortran")
 
+    depends_on("cmake@3.25:", when="@2026:", type="build")
     depends_on("cmake@3.23:", when="@2024.07.0:", type="build")
     depends_on("cmake@3.23:", when="@2022.10.0: +rocm", type="build")
     depends_on("cmake@3.20:", when="@2022.10.0:2024.02.1", type="build")


### PR DESCRIPTION
Umpire will move to C++20 for its next release. For this to work, cmake/3.25 or newer is required.

Since I don't know the exact version number for the next release, the depends statement just has "@2026:" as a way to say "all 2026 releases and later" - I think that should be ok.