### PR TITLE
hipblas common fix

### DIFF
--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -213,11 +213,11 @@
       prefix: /opt/rocm-6.1.2
     - spec: hipblas@6.2.4%llvm-amdgpu@6.2.4
       prefix: /opt/rocm-6.2.4
-    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1 ^hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3 ^hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0 ^hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
   hipblas-common:
     version: [6.3.1, 6.4.3, 7.2.0]

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -219,6 +219,7 @@
       prefix: /opt/rocm-6.4.3
     - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0 ^hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
+  # Note: does not depend on compiler
   hipblas-common:
     version: [6.3.1, 6.4.3, 7.2.0]
     buildable: false

--- a/toss_4_x86_64_ib_cray/packages.yaml
+++ b/toss_4_x86_64_ib_cray/packages.yaml
@@ -223,11 +223,11 @@
     version: [6.3.1, 6.4.3, 7.2.0]
     buildable: false
     externals:
-    - spec: hipblas-common@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas-common@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas-common@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
   hipsolver:
     version: [5.7.1, 6.1.2, 6.2.4, 6.3.1, 6.4.3, 7.2.0]

--- a/toss_4_x86_64_ib_cray/tioga/packages.yaml
+++ b/toss_4_x86_64_ib_cray/tioga/packages.yaml
@@ -213,21 +213,22 @@
       prefix: /opt/rocm-6.1.2
     - spec: hipblas@6.2.4%llvm-amdgpu@6.2.4
       prefix: /opt/rocm-6.2.4
-    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1 ^hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3 ^hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0 ^hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
+  # Note: does not depend on compiler
   hipblas-common:
     version: [6.3.1, 6.4.3, 7.2.0]
     buildable: false
     externals:
-    - spec: hipblas-common@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas-common@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas-common@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
   hipsolver:
     version: [5.7.1, 6.1.2, 6.2.4, 6.3.1, 6.4.3, 7.2.0]

--- a/toss_4_x86_64_ib_cray/tuolumne/packages.yaml
+++ b/toss_4_x86_64_ib_cray/tuolumne/packages.yaml
@@ -213,21 +213,22 @@
       prefix: /opt/rocm-6.1.2
     - spec: hipblas@6.2.4%llvm-amdgpu@6.2.4
       prefix: /opt/rocm-6.2.4
-    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas@6.3.1%llvm-amdgpu@6.3.1 ^hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas@6.4.3%llvm-amdgpu@6.4.3 ^hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas@7.2.0%llvm-amdgpu@7.2.0 ^hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
+  # Note: does not depend on compiler
   hipblas-common:
     version: [6.3.1, 6.4.3, 7.2.0]
     buildable: false
     externals:
-    - spec: hipblas-common@6.3.1%llvm-amdgpu@6.3.1
+    - spec: hipblas-common@6.3.1
       prefix: /opt/rocm-6.3.1
-    - spec: hipblas-common@6.4.3%llvm-amdgpu@6.4.3
+    - spec: hipblas-common@6.4.3
       prefix: /opt/rocm-6.4.3
-    - spec: hipblas-common@7.2.0%llvm-amdgpu@7.2.0
+    - spec: hipblas-common@7.2.0
       prefix: /opt/rocm-7.2.0
   hipsolver:
     version: [5.7.1, 6.1.2, 6.2.4, 6.3.1, 6.4.3, 7.2.0]


### PR DESCRIPTION
Follow up to https://github.com/llnl/radiuss-spack-configs/pull/162, but the minimally needed fixes for Quandary:
- remove compiler from hipblas-common-- The compiler in the spec used to work with Spack 1.0.2 but does not with 1.1.0+. The hipblas-common spack package actually does not depend on c/cxx now.
- add hipblas-common of the appropriate version to the hipblas external's spec. Since Spack 1.1.0 externals can have dependencies, and otherwise it is not choosing matching versions for hipblas and hipblas-common and PETSc fails to build. This relationship is present in the package.py for hipblas, but I believe this is still needed for the external (see [here](https://spack.readthedocs.io/en/latest/packages_yaml.html#specifying-dependencies-among-external-packages))

Tested with Quandary: ([CI pipeline](https://lc.llnl.gov/gitlab/quantum1/quandary/-/pipelines/694591) and [Quandary PR](https://github.com/llnl/quandary/pull/120/changes#diff-8d1105a9c8e057ebe71e485af5c41923bf2f07b7a019d025a48b0a0963feeff8) using this branch)