### PR TITLE
ci: Bump Corona rocm version

### DIFF
--- a/gitlab/radiuss-jobs/corona.yml
+++ b/gitlab/radiuss-jobs/corona.yml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-rocmcc_5_7_1_hip:
+rocmcc_6_4_3_hip:
   variables:
-    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=5.7.1 ^hip@5.7.1 ${PROJECT_CORONA_DEPS}"
+    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.3 ^hip@6.4.3 ${PROJECT_CORONA_DEPS}"
   extends: .job_on_corona

--- a/gitlab/radiuss-jobs/corona.yml
+++ b/gitlab/radiuss-jobs/corona.yml
@@ -8,4 +8,5 @@
 rocmcc_6_4_2_hip:
   variables:
     SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.2 ^hip@6.4.2 ${PROJECT_CORONA_DEPS}"
+    MODULE_LIST: "rocm/6.4.2"
   extends: .job_on_corona

--- a/gitlab/radiuss-jobs/corona.yml
+++ b/gitlab/radiuss-jobs/corona.yml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-rocmcc_6_4_3_hip:
+rocmcc_6_4_2_hip:
   variables:
-    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.3 ^hip@6.4.3 ${PROJECT_CORONA_DEPS}"
+    SPEC: "${PROJECT_CORONA_VARIANTS} +rocm amdgpu_target=gfx906 %llvm-amdgpu@=6.4.2 ^hip@6.4.2 ${PROJECT_CORONA_DEPS}"
   extends: .job_on_corona

--- a/toss_4_x86_64_ib/corona/packages.yaml
+++ b/toss_4_x86_64_ib/corona/packages.yaml
@@ -26,7 +26,7 @@
     - one_of: ['%intel-oneapi-compilers', '%intel-oneapi-compilers-classic']
 
   # compilers
-  gcc:
+  gc:
     externals:
     - spec: gcc@10.3.1 languages='c,c++,fortran'
       prefix: /usr/tce/packages/gcc/gcc-10.3.1
@@ -158,7 +158,7 @@
       prefix: /opt/rocm-6.0.2
       extra_attributes:
         compilers:
-          cc: /opt/rocm-6.0.2/llvm/bin/amdclang
+          c: /opt/rocm-6.0.2/llvm/bin/amdclang
           cxx: /opt/rocm-6.0.2/llvm/bin/amdclang++
           fortran: /opt/rocm-6.0.2/llvm/bin/amdflang
         flags: {}
@@ -168,7 +168,7 @@
       prefix: /opt/rocm-6.4.2/llvm
       extra_attributes:
         compilers:
-          cc: /opt/rocm-6.4.2/llvm/bin/amdclang
+          c: /opt/rocm-6.4.2/llvm/bin/amdclang
           cxx: /opt/rocm-6.4.2/llvm/bin/amdclang++
           fortran: /opt/rocm-6.4.2/llvm/bin/amdflang
         flags: {}

--- a/toss_4_x86_64_ib/corona/packages.yaml
+++ b/toss_4_x86_64_ib/corona/packages.yaml
@@ -26,7 +26,7 @@
     - one_of: ['%intel-oneapi-compilers', '%intel-oneapi-compilers-classic']
 
   # compilers
-  gc:
+  gcc:
     externals:
     - spec: gcc@10.3.1 languages='c,c++,fortran'
       prefix: /usr/tce/packages/gcc/gcc-10.3.1

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -178,7 +178,7 @@
       prefix: /opt/rocm-6.0.2
       extra_attributes:
         compilers:
-          cc: /opt/rocm-6.0.2/llvm/bin/amdclang
+          c: /opt/rocm-6.0.2/llvm/bin/amdclang
           cxx: /opt/rocm-6.0.2/llvm/bin/amdclang++
           fortran: /opt/rocm-6.0.2/llvm/bin/amdflang
         flags: {}
@@ -188,7 +188,7 @@
       prefix: /opt/rocm-6.4.2/llvm
       extra_attributes:
         compilers:
-          cc: /opt/rocm-6.4.2/llvm/bin/amdclang
+          c: /opt/rocm-6.4.2/llvm/bin/amdclang
           cxx: /opt/rocm-6.4.2/llvm/bin/amdclang++
           fortran: /opt/rocm-6.4.2/llvm/bin/amdflang
         flags: {}


### PR DESCRIPTION
We no longer want to support rocm 5.7.1.  @adrienbernede  @tdrwenski  is this sufficient to bump the CI version? used here https://github.com/llnl/RAJA/pull/2045