### PR TITLE
Stop setting spack-packages builtin repo ref in shared environment

### DIFF
--- a/.gitlab/spack/envs/cached-cmake/spack.yaml
+++ b/.gitlab/spack/envs/cached-cmake/spack.yaml
@@ -8,12 +8,6 @@
 
 spack:
   #[general--]
-  repos:
-    ## Use for temporary testing purpose, comment out before merging to main branch:
-    #llnl_radiuss: ./spack_repo/llnl_radiuss/
-    builtin:
-      git: https://github.com/spack/spack-packages.git
-      commit: e4c0b2d275f9b4714f80156f79f1e29347dedf16
   include:
   - $LCSCHEDCLUSTER/config.yaml
   - $LCSCHEDCLUSTER/packages.yaml

--- a/.gitlab/spack/envs/shared-ci/spack.yaml
+++ b/.gitlab/spack/envs/shared-ci/spack.yaml
@@ -8,12 +8,6 @@
 
 spack:
   #[general--]
-  repos:
-    ## Use for temporary testing purpose, comment out before merging to main branch:
-    #llnl_radiuss: ./spack_repo/llnl_radiuss/
-    builtin:
-      git: https://github.com/spack/spack-packages.git
-      commit: e4c0b2d275f9b4714f80156f79f1e29347dedf16
   include:
   - $LCSCHEDCLUSTER/config.yaml
   - $LCSCHEDCLUSTER/packages.yaml

--- a/toss_4_x86_64_ib/corona/packages.yaml
+++ b/toss_4_x86_64_ib/corona/packages.yaml
@@ -145,7 +145,7 @@
         environment: {}
         extra_rpaths: [/opt/rocm-6.0.2/lib, /opt/rocm-6.0.2/llvm/lib]
     - spec: llvm-amdgpu@6.4.3
-      prefix: /opt/rocm-6.4.3/llvm
+      prefix: /opt/rocm-6.4.3
       extra_attributes:
         compilers:
           c: /opt/rocm-6.4.3/llvm/bin/amdclang

--- a/toss_4_x86_64_ib/packages.yaml
+++ b/toss_4_x86_64_ib/packages.yaml
@@ -165,7 +165,7 @@
         environment: {}
         extra_rpaths: [/opt/rocm-6.0.2/lib, /opt/rocm-6.0.2/llvm/lib]
     - spec: llvm-amdgpu@6.4.3
-      prefix: /opt/rocm-6.4.3/llvm
+      prefix: /opt/rocm-6.4.3
       extra_attributes:
         compilers:
           c: /opt/rocm-6.4.3/llvm/bin/amdclang

--- a/toss_4_x86_64_ib/spack.yaml
+++ b/toss_4_x86_64_ib/spack.yaml
@@ -1,8 +1,4 @@
 spack:
-  repos:
-    builtin::
-      git: https://github.com/spack/spack-packages.git
-      commit: e4c0b2d275f9b4714f80156f79f1e29347dedf16
   include:
     - config.yaml
     - packages.yaml

--- a/toss_4_x86_64_ib_cray/spack.yaml
+++ b/toss_4_x86_64_ib_cray/spack.yaml
@@ -1,8 +1,4 @@
 spack:
-  repos:
-    builtin::
-      git: https://github.com/spack/spack-packages.git
-      commit: e4c0b2d275f9b4714f80156f79f1e29347dedf16
   include:
     - config.yaml
     - packages.yaml


### PR DESCRIPTION
The RAJA team has been having a hard time trying to test changes in projects approaching a release deadline. The problem is that with spack-packages ref pinned in radiuss-spack-configs, the process to change a package is cumbersome: push a PR in spack-packages, then open a PR in radiuss-spack-configs, and point your project at radiuss-spack-config branch. Each change to the packages requiring the update of radiuss-spack-configs.

So... I changed my mind and suggest we give up enforcing the spack-packages reference in radiuss-spack-configs to allow developers to maintain the spack-packages more responsively.

This PR just remove the reference from the shared environments.

Each project will have to set the spack-packages reference in their .uberenv_config.json. (I have the corresponding PRs ready).

Note: This is how Smith and Axom set their spack-packages reference

## Related PRs:
- https://github.com/llnl/Caliper/pull/749
- https://github.com/llnl/CARE/pull/386
- https://github.com/llnl/CHAI/pull/379
- https://github.com/llnl/RAJA/pull/2064
- https://github.com/llnl/Umpire/pull/1092
- https://github.com/llnl/RAJAPerf/pull/698

