### PR TITLE
Restore needed spack-packages reference for RSC CI

### DIFF
--- a/.gitlab/spack/envs/cached-cmake/spack.yaml
+++ b/.gitlab/spack/envs/cached-cmake/spack.yaml
@@ -8,6 +8,12 @@
 
 spack:
   #[general--]
+  repos:
+    ## Use for temporary testing purpose, comment out before merging to main branch:
+    #llnl_radiuss: ./spack_repo/llnl_radiuss/
+    builtin:
+      git: https://github.com/spack/spack-packages.git
+      commit: 4d3d0f8ee5ffd6f099727f46ec704f3f4ee98e5c
   include:
   - $LCSCHEDCLUSTER/config.yaml
   - $LCSCHEDCLUSTER/packages.yaml

--- a/.gitlab/spack/envs/shared-ci/spack.yaml
+++ b/.gitlab/spack/envs/shared-ci/spack.yaml
@@ -8,6 +8,12 @@
 
 spack:
   #[general--]
+  repos:
+    ## Use for temporary testing purpose, comment out before merging to main branch:
+    #llnl_radiuss: ./spack_repo/llnl_radiuss/
+    builtin:
+      git: https://github.com/spack/spack-packages.git
+      commit: 4d3d0f8ee5ffd6f099727f46ec704f3f4ee98e5c
   include:
   - $LCSCHEDCLUSTER/config.yaml
   - $LCSCHEDCLUSTER/packages.yaml


### PR DESCRIPTION
- Restore needed spack-packages reference for RSC CI
- Update Release Notes

TODO:
- [ ] Update spack-packages reference with latest changes (RADIUSS projects releases).
- [ ] Test in the context of RADIUSS Projects.